### PR TITLE
Add `linter` command after protoc generation

### DIFF
--- a/.github/workflows/dart-video-proto.yml
+++ b/.github/workflows/dart-video-proto.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Compile definitions
-        run: docker run -v $(pwd):/local ghcr.io/getstream/protocol dart /local/dart-sdk
+        run: docker run -v $(pwd):/local ghcr.io/getstream/protobuf-generate dart /local/dart-sdk

--- a/.github/workflows/swift-video-proto.yml
+++ b/.github/workflows/swift-video-proto.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Compile definitions
-        run: docker run -v $(pwd):/local ghcr.io/getstream/protocol swift /local/swift-sdk
+        run: docker run -v $(pwd):/local ghcr.io/getstream/protobuf-generate swift /local/swift-sdk

--- a/.github/workflows/typescript-video-proto.yml
+++ b/.github/workflows/typescript-video-proto.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Compile definitions
-        run: docker run -v $(pwd):/local ghcr.io/getstream/protocol ts /local/ts-sdk
+        run: docker run -v $(pwd):/local ghcr.io/getstream/protobuf-generate ts /local/ts-sdk

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "arrowParens": "always",
+  "printWidth": 80,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "singleQuote": true
+}

--- a/generate.sh
+++ b/generate.sh
@@ -52,6 +52,12 @@ case $GEN_PROFILE in
       --twirp_out=paths=source_relative:$GEN_OUTPUT
 EOF
     )
+
+    linter=$(cat << EOF
+    go fmt $GEN_OUTPUT/...
+EOF
+    )
+
     # Map imports
     for DIR in $PROTO_DIRS; do
       DIR=$(${REALPATH} --relative-to "$PB" "$DIR")
@@ -79,6 +85,11 @@ EOF
 EOF
     )
 
+    linter=$(cat << EOF
+    echo
+EOF
+    )
+
     # Map imports
     for DIR in $PROTO_DIRS; do
       DIR=$(${REALPATH} --relative-to "$PB" "$DIR")
@@ -102,6 +113,11 @@ EOF
       --ts_opt eslint_disable
 EOF
     )
+
+    linter=$(cat << EOF
+    prettier --write $GEN_OUTPUT/**/*.ts
+EOF
+    )
     ;;
 
   swift)
@@ -118,6 +134,11 @@ EOF
       --swift_opt=FileNaming=FullPath
       --swift_out=$GEN_OUTPUT
       --swift-twirp_out=paths=source_relative:$GEN_OUTPUT
+EOF
+    )
+
+    linter=$(cat << EOF
+    echo
 EOF
     )
 
@@ -144,6 +165,7 @@ for DIR in $PROTO_DIRS; do
   ARGS=$PROTOC_ARGS
   if [[ ${FILES} ]]; then
     $protoc ${ARGS} ${FILES}
+    $linter
   fi
 done
 

--- a/install.sh
+++ b/install.sh
@@ -80,8 +80,9 @@ if command -v yarn &> /dev/null
 then
   echo "Installing typescript protoc plugin"
   mkdir $PROTOC_DIR/.typescript-protobuf
-  (cd $PROTOC_DIR/.typescript-protobuf && yarn add @protobuf-ts/plugin@2.8.1 --no-lockfile --disable-pnp)
+  (cd $PROTOC_DIR/.typescript-protobuf && yarn add @protobuf-ts/plugin@2.9.0 prettier@2.8.8 --no-lockfile --disable-pnp)
   ln -s $PROTOC_DIR/.typescript-protobuf/node_modules/.bin/protoc-gen-ts $PROTOC_DIR/bin/protoc-gen-ts
+  ln -s $PROTOC_DIR/.typescript-protobuf/node_modules/.bin/prettier $PROTOC_DIR/bin/prettier
 else
   echo 'yarn is not installed. Skipping...'
 fi


### PR DESCRIPTION
This allow to run a linter (or formatter) after protoc is generated, is possible to run different linters for different languages.

Signed-off-by: Federico Guerinoni <federico.guerinoni@getstream.io>
