### PR TITLE
add manage call types page

### DIFF
--- a/docusaurus/video/docusaurus/docs/api/call_types/geofencing.mdx
+++ b/docusaurus/video/docusaurus/docs/api/call_types/geofencing.mdx
@@ -4,3 +4,35 @@ sidebar_position: 3
 slug: /call_types/geofencing
 title: Geofencing
 ---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+client.createCallType({
+  name: '<call type name>',
+  settings: {
+    geofencing: {
+      names: ['european_union'],
+    },
+  },
+});
+
+//override settings on call level
+call.create({
+  data: {
+    created_by_id: 'john',
+    settings_override: {
+      geofencing: {
+        names: ['european_union'],
+      },
+    },
+  },
+});
+```
+
+</TabItem>
+</Tabs>

--- a/docusaurus/video/docusaurus/docs/api/call_types/manage-types.mdx
+++ b/docusaurus/video/docusaurus/docs/api/call_types/manage-types.mdx
@@ -1,0 +1,77 @@
+---
+id: manage_types
+sidebar_position: 2
+slug: /call_types/manage
+title: Manage Types
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+## Read call types
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+client.getCallTypes();
+
+//or
+client.getCallType('livestream');
+```
+
+</TabItem>
+</Tabs>
+
+## Create call type
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+client.createCallType({
+  name: 'allhands',
+  settings: {
+    audio: { mic_default_on: true, default_device: 'speaker' },
+  },
+  grants: {
+    admin: [
+      OwnCapability.SEND_AUDIO,
+      OwnCapability.SEND_VIDEO,
+      OwnCapability.MUTE_USERS,
+    ],
+    user: [OwnCapability.SEND_AUDIO, OwnCapability.SEND_VIDEO],
+  },
+});
+```
+
+</TabItem>
+</Tabs>
+
+## Update call type
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+client.updateCallType('allhands', {
+  settings: {
+    audio: { mic_default_on: false, default_device: 'earpiece' },
+  },
+});
+```
+
+</TabItem>
+</Tabs>
+
+## Delete call type
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+client.deleteCallType('allhands');
+```
+
+</TabItem>
+</Tabs>

--- a/docusaurus/video/docusaurus/docs/api/call_types/permissions.mdx
+++ b/docusaurus/video/docusaurus/docs/api/call_types/permissions.mdx
@@ -4,3 +4,26 @@ sidebar_position: 3
 slug: /call_types/permissions
 title: Permissions
 ---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+client.createCallType({
+  name: '<call type name>',
+  grants: {
+    admin: [
+      OwnCapability.SEND_AUDIO,
+      OwnCapability.SEND_VIDEO,
+      OwnCapability.MUTE_USERS,
+    ],
+    user: [OwnCapability.SEND_AUDIO, OwnCapability.SEND_VIDEO],
+  },
+});
+```
+
+</TabItem>
+</Tabs>

--- a/docusaurus/video/docusaurus/docs/api/call_types/permissions.mdx
+++ b/docusaurus/video/docusaurus/docs/api/call_types/permissions.mdx
@@ -1,6 +1,6 @@
 ---
 id: call_types_permissions
-sidebar_position: 2
+sidebar_position: 3
 slug: /call_types/permissions
 title: Permissions
 ---

--- a/docusaurus/video/docusaurus/docs/api/call_types/settings.mdx
+++ b/docusaurus/video/docusaurus/docs/api/call_types/settings.mdx
@@ -4,3 +4,64 @@ sidebar_position: 5
 slug: /call_types/settings
 title: Settings
 ---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+## Settings
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+client.createCallType({
+  name: '<call type name>',
+  settings: {
+    screensharing: {
+      access_request_enabled: false,
+      enabled: true,
+    },
+  },
+});
+
+// override settings on call level
+call.create({
+  data: {
+    created_by_id: 'john',
+    settings_override: {
+      screensharing: {
+        enabled: false,
+      },
+    },
+  },
+});
+```
+
+</TabItem>
+</Tabs>
+
+## Notification settings
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+client.createCallType({
+  name: '<call type name>',
+  notification_settings: {
+    enabled: true,
+    call_notification: {
+      apns: {
+        title: '{{ user.display_name }} invites you to a call',
+      },
+      enabled: true,
+    },
+    session_started: {
+      enabled: false,
+    },
+  },
+});
+```
+
+</TabItem>
+</Tabs>

--- a/docusaurus/video/docusaurus/docs/api/call_types/settings.mdx
+++ b/docusaurus/video/docusaurus/docs/api/call_types/settings.mdx
@@ -1,6 +1,6 @@
 ---
 id: call_types_settings
-sidebar_position: 4
+sidebar_position: 5
 slug: /call_types/settings
 title: Settings
 ---


### PR DESCRIPTION
I couldn't find an existing page where we could showcase the call type CRUD API, so I added a "Manage Types" page. Let me know if it should go somewhere else.