### PR TITLE
DON'T MERGE fix chat open to allow code generation

### DIFF
--- a/openapi/chat-openapi.yaml
+++ b/openapi/chat-openapi.yaml
@@ -13667,6 +13667,24 @@ paths:
       - content:
           application/json:
             schema:
+              type: string
+              writeOnly: true
+              x-stream-index: "001.001"
+        in: path
+        name: type
+        required: true
+      - content:
+          application/json:
+            schema:
+              type: string
+              writeOnly: true
+              x-stream-index: "001.002"
+        in: path
+        name: id
+        required: true
+      - content:
+          application/json:
+            schema:
               description: File URL to delete
               title: URL
               type: string
@@ -13874,6 +13892,24 @@ paths:
         - DeleteAttachment
       operationId: DeleteImage
       parameters:
+      - content:
+          application/json:
+            schema:
+              type: string
+              writeOnly: true
+              x-stream-index: 001.001.001
+        in: path
+        name: type
+        required: true
+      - content:
+          application/json:
+            schema:
+              type: string
+              writeOnly: true
+              x-stream-index: 001.001.002
+        in: path
+        name: id
+        required: true
       - content:
           application/json:
             schema:
@@ -15743,7 +15779,7 @@ paths:
     post:
       description: |
         Exports user profile, reactions and messages for list of given users
-      operationId: ExportUser
+      operationId: ExportUsers
       requestBody:
         content:
           application/json:
@@ -16394,6 +16430,18 @@ paths:
         - SkipMessageModeration
         - UpdateMessage
       operationId: UpdateMessage
+      parameters:
+      - content:
+          application/json:
+            schema:
+              description: Message ID
+              title: ID
+              type: string
+              writeOnly: true
+              x-stream-index: "001"
+        in: path
+        name: id
+        required: true
       requestBody:
         content:
           application/json:
@@ -16462,6 +16510,18 @@ paths:
         - SkipMessageModeration
         - UpdateMessage
       operationId: UpdateMessagePartial
+      parameters:
+      - content:
+          application/json:
+            schema:
+              description: Message ID
+              title: ID
+              type: string
+              writeOnly: true
+              x-stream-index: "001"
+        in: path
+        name: id
+        required: true
       requestBody:
         content:
           application/json:
@@ -16921,6 +16981,18 @@ paths:
         Required permissions:
         - ReadChannel
       operationId: TranslateMessage
+      parameters:
+      - content:
+          application/json:
+            schema:
+              description: Message ID
+              title: ID
+              type: string
+              writeOnly: true
+              x-stream-index: "001"
+        in: path
+        name: id
+        required: true
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
DON'T MERGE THIS PR, IT CHANGES GENERATED FILES

When running the open API code generator on the chat API spec these errors were returned:

```
-paths.'/messages/{id}'. Declared path parameter id needs to be defined as a path parameter in path or operation level
-paths.'/channels/{type}/{id}/image'. Declared path parameter id needs to be defined as a path parameter in path or operation level
-paths.'/channels/{type}/{id}/file'. Declared path parameter type needs to be defined as a path parameter in path or operation level
-paths.'/channels/{type}/{id}/image'. Declared path parameter type needs to be defined as a path parameter in path or operation level
-paths.'/channels/{type}/{id}/file'. Declared path parameter id needs to be defined as a path parameter in path or operation level
-paths.'/messages/{id}/translate'. Declared path parameter id needs to be defined as a path parameter in path or operation level
-attribute paths.'/users/{user_id}/export'(get).operationId is repeated
```

The PR contains a fix to them