### PR TITLE
API docs updates

### DIFF
--- a/docusaurus/video/docusaurus/docs/api/_common_/broadcast.mdx
+++ b/docusaurus/video/docusaurus/docs/api/_common_/broadcast.mdx
@@ -1,0 +1,33 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+call.startHLSBroadcasting();
+
+// to end broadcasting
+call.stopHLSBroadcasting();
+```
+
+</TabItem>
+<TabItem value="py" label="Python">
+
+```py
+call.start_broadcasting()
+
+// to end broadcasting
+call.stop_broadcasting()
+```
+
+</TabItem>
+<TabItem value="curl" label="cURL">
+
+```bash
+curl -X POST "https://video.stream-io-api.com/video/call/default/${CALL_ID}/start_broadcasting?api_key=${API_KEY}" \
+-H "Authorization: ${JWT_TOKEN}"
+```
+
+</TabItem>
+</Tabs>

--- a/docusaurus/video/docusaurus/docs/api/_common_/go_live.mdx
+++ b/docusaurus/video/docusaurus/docs/api/_common_/go_live.mdx
@@ -6,6 +6,9 @@ import TabItem from '@theme/TabItem';
 
 ```js
 call.goLive();
+
+// optionally start HLS broadcast and/or recording
+call.goLive({ start_hls: true, start_recording: true });
 ```
 
 </TabItem>

--- a/docusaurus/video/docusaurus/docs/api/basics/authentication.mdx
+++ b/docusaurus/video/docusaurus/docs/api/basics/authentication.mdx
@@ -37,6 +37,17 @@ await client.upsertUsers({
 ```
 
 </TabItem>
+<TabItem value="py" label="Python">
+
+```py
+users = {}
+users["userid"] = UserRequest(
+id=user_id, role="user", custom={"color": "red"}, name="This is a test user",image: "link/to/profile/image",
+)
+client.upsert_users(users=users)
+```
+
+</TabItem>
 </Tabs>
 
 ## Updating users
@@ -113,6 +124,8 @@ const guest = (await client.createGuest({ user: guest })).user;
 While it is usually safer for data retention to deactivate a user, some use cases require completely deleting a user and their data.
 
 Once a user has been deleted, it cannot be un-deleted and the user_id cannot be used again.
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
 
 ```js
 client.deactivateUser({
@@ -121,6 +134,8 @@ client.deactivateUser({
 
 client.deleteUser({ userId: '<id>' });
 ```
+</TabItem>
+</Tabs>
 
 ## User tokens
 

--- a/docusaurus/video/docusaurus/docs/api/basics/authentication.mdx
+++ b/docusaurus/video/docusaurus/docs/api/basics/authentication.mdx
@@ -41,9 +41,10 @@ await client.upsertUsers({
 
 ```py
 users = {}
-users["userid"] = UserRequest(
-id=user_id, role="user", custom={"color": "red"}, name="This is a test user",image: "link/to/profile/image",
+user = UserRequest(
+id='user_id', role="user", custom={"color": "red"}, name="This is a test user",image= "link/to/profile/image",
 )
+users[user.id] = user
 client.upsert_users(users=users)
 ```
 
@@ -91,6 +92,38 @@ client.updateUsersPartial({
 ```
 
 </TabItem>
+<TabItem value="py" label="Python">
+
+```py
+users = {}
+user = UserRequest(
+  id= 'userid',
+  role= 'user',
+  custom= {
+    "color": 'red',
+  },
+  name= 'This is a test user',
+  image= 'link/to/profile/image',
+)
+
+users[user.id] = user
+client.upsert_users(users=users)
+
+// or
+client.update_users_partial(
+  users= [
+    {
+      id: user.id,
+      set: {
+        color: 'blue',
+      },
+      unset: ['name'],
+    },
+  ],
+)
+```
+
+</TabItem>
 </Tabs>
 
 ## Anonymous users
@@ -117,6 +150,21 @@ const guest = (await client.createGuest({ user: guest })).user;
 ```
 
 </TabItem>
+<TabItem value="py" label="Python">
+
+```py
+guest = UserRequest(
+  id = '<id>',
+  name= '<name>',
+  custom= {
+    "color": 'red',
+  },
+)
+
+guest = (client.video.create_guest(user=guest)).user
+```
+
+</TabItem>
 </Tabs>
 
 ## Deactivating and deleting users
@@ -134,6 +182,18 @@ client.deactivateUser({
 });
 
 client.deleteUser({ userId: '<id>' });
+```
+
+</TabItem>
+
+<TabItem value="py" label="Python">
+
+```py
+client.deactivate_user(
+  user_id= '<id>',
+)
+
+client.delete_user( user_id= '<id>' )
 ```
 
 </TabItem>

--- a/docusaurus/video/docusaurus/docs/api/basics/authentication.mdx
+++ b/docusaurus/video/docusaurus/docs/api/basics/authentication.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 ## Creating users
 
-Stream Users require only an id to be created. Users can be created with role of user or admin. The role will be set to user if a value is not provided in the request. There are additional properties you can provide to further describe your users.
+Stream Users require only an ID to be created. Users can be created with the role of user or admin. The role will be set to user if a value is not provided in the request. There are additional properties you can provide to further describe your users.
 
 The `name` and `image` fields are special fields that are supported by client-side SDKs.
 
@@ -55,7 +55,7 @@ client.upsert_users(users=users)
 There are two ways to update user objects:
 
 - Updating will replace the existing user object
-- Partial update will let you choose which fields you want to chage/unset
+- Partial update will let you choose which fields you want to change/unset
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
@@ -99,7 +99,7 @@ Anonymous users are users that are not authenticated. It's common to use this fo
 
 ## Guest users
 
-Guest users are temporary user accounts. You can use it to temporarily give someone a name and image when joining a call. Guest users can aslso be created cliend-side.
+Guest users are temporary user accounts. You can use it to temporarily give someone a name and image when joining a call. Guest users can aslso be created client-side.
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
@@ -123,7 +123,7 @@ const guest = (await client.createGuest({ user: guest })).user;
 
 While it is usually safer for data retention to deactivate a user, some use cases require completely deleting a user and their data.
 
-Once a user has been deleted, it cannot be un-deleted and the user_id cannot be used again.
+Once a user has been deleted, it cannot be un-deleted, and the user_id cannot be used again.
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
@@ -141,12 +141,12 @@ client.deleteUser({ userId: '<id>' });
 
 ## User tokens
 
-Stream uses JWT (JSON Web Tokens) to authenticate chat users, enabling them to login. Knowing whether a user is authorized to perform certain actions is managed separately via a role based permissions system. Tokens need to be generated server-side.
+Stream uses JWT (JSON Web Tokens) to authenticate chat users, enabling them to log in. Knowing whether a user is authorized to perform certain actions is managed separately via a role-based permissions system. Tokens need to be generated server-side.
 
 You can optionally provide
 
 - Expiration time. By default tokens don't have an expiration date.
-- Issued at date which is necessary if you manually wan to revoke tokens. By default the issued at date is set to the current date.
+- Issued at date, which is necessary if you manually want to revoke tokens. By default, the issued at date is set to the current date.
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
@@ -221,5 +221,5 @@ client.create_token(user_id=user_id, exp, iat, call_cids)
 
 ## Provisioning token in production
 
-Your authentication service is responsible for generating token for your users. It is highly recommended to always create tokens with an expiration.
-All SDK make it easy to automatically re-fetch tokens from your backend servers with token providers when they expire.
+Your authentication service is responsible for generating tokens for your users. It is highly recommended to always create tokens with an expiration.
+All SDKs make it easy to automatically re-fetch tokens from your backend servers with token providers when they expire.

--- a/docusaurus/video/docusaurus/docs/api/basics/authentication.mdx
+++ b/docusaurus/video/docusaurus/docs/api/basics/authentication.mdx
@@ -124,6 +124,7 @@ const guest = (await client.createGuest({ user: guest })).user;
 While it is usually safer for data retention to deactivate a user, some use cases require completely deleting a user and their data.
 
 Once a user has been deleted, it cannot be un-deleted and the user_id cannot be used again.
+
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
 
@@ -134,6 +135,7 @@ client.deactivateUser({
 
 client.deleteUser({ userId: '<id>' });
 ```
+
 </TabItem>
 </Tabs>
 
@@ -143,8 +145,8 @@ Stream uses JWT (JSON Web Tokens) to authenticate chat users, enabling them to l
 
 You can optionally provide
 
-- expiration time
-- issued at date which is necessary if you manually wan to revoke tokens
+- Expiration time. By default tokens don't have an expiration date.
+- Issued at date which is necessary if you manually wan to revoke tokens. By default the issued at date is set to the current date.
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
@@ -194,12 +196,7 @@ const iat = Math.round(new Date().getTime() / 1000);
 
 const call_cids = ['default:call1', 'livestream:call2'];
 
-client.createToken(
-  (user_id = user_id),
-  (exp = exp),
-  (iat = iat),
-  (call_cids = call_cids),
-);
+client.createCallToken(userId, call_cids, exp, iat);
 ```
 
 </TabItem>

--- a/docusaurus/video/docusaurus/docs/api/basics/calls.mdx
+++ b/docusaurus/video/docusaurus/docs/api/basics/calls.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 
 You can create a call by providing the call type and an ID:
 
-- The [call type](call_types/builtin) controls which features are enabled, and sets up permissions.
+- The [call type](call_types/builtin) controls which features are enabled and sets up permissions.
 - Calls IDs can be reused, which means they can be joined multiple times, so it's possible to set up recurring calls.
 
 You can optionally restrict call access by providing a list of users.
@@ -145,7 +145,7 @@ curl -X PUT "https://video.stream-io-api.com/video/call/default/${CALL_ID}?api_k
 
 ## Manage call members
 
-Call members can be added and removed as necessary. Their role's can also be changed.
+Call members can be added and removed as necessary. Their roles can also be changed.
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
@@ -210,7 +210,7 @@ For many video calling, live stream, or audio rooms apps, you'll want to show:
 - Calls that are currently live
 - Popular live streams / audio rooms with a link to the recording
 
-Below you can find a few examples of different quieries:
+Below you can find a few examples of different queries:
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
@@ -268,7 +268,7 @@ client.query_calls(
 </TabItem>
 </Tabs>
 
-Filter expressions support multiple match criteria and it's also possible to combine filters. For more information visit the [filter operators](https://getstream.io/chat/docs/node/query_syntax_operators/?language=javascript) guide.
+Filter expressions support multiple match criteria, and it's also possible to combine filters. For more information, visit the [filter operators](https://getstream.io/chat/docs/node/query_syntax_operators/?language=javascript) guide.
 
 ## Query call members
 
@@ -328,4 +328,4 @@ call.query_members(
 </TabItem>
 </Tabs>
 
-Filter expressions support multiple match criteria and it's also possible to combine filters. For more information visit the [filter operators](https://getstream.io/chat/docs/node/query_syntax_operators/?language=javascript) guide.
+Filter expressions support multiple match criteria, and it's also possible to combine filters. For more information, visit the [filter operators](https://getstream.io/chat/docs/node/query_syntax_operators/?language=javascript) guide.

--- a/docusaurus/video/docusaurus/docs/api/basics/calls.mdx
+++ b/docusaurus/video/docusaurus/docs/api/basics/calls.mdx
@@ -43,13 +43,13 @@ call.create({
 
 ```py
 # create a call
-call.get_or_create_call(
+call.create(
     data=CallRequest(
         created_by_id='john'
     )
 )
 # create a call with more data
-call.get_or_create_call(
+call.create(
     data=CallRequest(
         created_by_id='john',
         members=[
@@ -109,7 +109,7 @@ call.update({ custom: { color: 'red' } });
 
 ```py
 # update call settings
-call.update_call(
+call.update(
     settings_override=CallSettingsRequest(
         audio=AudioSettingsRequest(
             mic_default_on=True,
@@ -118,7 +118,7 @@ call.update_call(
 )
 
 # update call with custom data
-call.update_call(
+call.update(
     custom={'color': 'red'}
 )
 ```
@@ -168,7 +168,7 @@ call.updateCallMembers({
 ```py
 # update or add call members
 
-call.update_call(
+call.update_members(
     members=[
         MemberRequest(user_id: 'sara'),
         MemberRequest(user_id: 'jack', role: 'admin')
@@ -177,7 +177,7 @@ call.update_call(
 
 # remove call members
 # Assuming the updated call members are 'sara' and 'jack'
-call.update_call(
+call.update_members(
     members=[
         MemberRequest(user_id: 'jack', role: 'admin')
     ]
@@ -244,23 +244,23 @@ client.video.queryCalls({
 
 ```py
 # default sorting
-call.query_calls(data=QueryCallsRequest())
+client.query_calls()
 
 # sorting and pagination
-response = call.query_calls(
+response = client.query_calls(
     sort= [SortParamRequest(field: 'starts_at', direction: -1)],
     limit=2,
 )
 
 # loading next page
-call.query_calls(
+client.query_calls(
     sort= [SortParamRequest(field: 'starts_at', direction: -1)],
     limit=2,
     next=response.data().next
 )
 
 # filtering
-call.query_calls(
+client.query_calls(
     filter_conditions={'backstage': {'$eq': False}}
 )
 ```

--- a/docusaurus/video/docusaurus/docs/api/basics/get_started.mdx
+++ b/docusaurus/video/docusaurus/docs/api/basics/get_started.mdx
@@ -125,7 +125,7 @@ call.create({
 from getstream.models.call_request import CallRequest
 
 call = client.video.call("default", "id")
-response = call.get_or_create_call(
+response = call.create(
     data=CallRequest(
         created_by_id="sacha",
     ),
@@ -167,7 +167,7 @@ call.updateCallMembers({
 <TabItem value="py" label="Python">
 
 ```py
-call.update_call_members(update_members=[
+call.update_members(update_members=[
             MemberRequest(user_id: "sara"),
             MemberRequest(user_id: "emily", role: "admin")])
 ```
@@ -351,7 +351,7 @@ call.listRecordings();
 <TabItem value="py" label="Python">
 
 ```py
-recordings = call.list_recordings(session="your_session_id")
+recordings = call.list_recordings()
 ```
 
 </TabItem>

--- a/docusaurus/video/docusaurus/docs/api/basics/get_started.mdx
+++ b/docusaurus/video/docusaurus/docs/api/basics/get_started.mdx
@@ -9,15 +9,15 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import RTMP from '../_common_/rtmp.mdx';
 
-For the average Stream integration, the development work focuses on code that executes in the client. However, some tasks must be executed from the server for safety (for example token generation).
+For the average Stream integration, the development work focuses on code that executes in the client. However, some tasks must be executed from the server for safety (for example, token generation).
 
-Stream provides server-side SDKs to help executing these tasks.
+Stream provides server-side SDKs to help execute these tasks.
 
 You can reference our [development roadmap](https://github.com/GetStream/protocol/discussions/177) to know which languages and features are supported.
 
 ## Installation
 
-All official SDK are available on package managers, full source code is available on the GetStream Github organization.
+All official SDKs are available on package managers, full source code is available on the GetStream Github organization.
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
@@ -40,7 +40,7 @@ pip install getstream
 
 ## Creating client
 
-To create a server-side client you'll need your **API key** and **secret**, both of them can be found in your [Stream Dashboard](https://dashboard.getstream.io/).
+To create a server-side client, you'll need your **API key** and **secret**. Both of them can be found in your [Stream Dashboard](https://dashboard.getstream.io/).
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
@@ -65,7 +65,7 @@ client = Stream(api_key="your_api_key", api_secret="your_api_secret")
 
 ## Creating user tokens
 
-Tokens need to be generated server-side. Typically you integrate this into the part of your codebase where you login or register users. The tokens provide a way to authenticate a user or give access to a specific set of video/audio calls.
+Tokens need to be generated server-side. Typically, you integrate this into the part of your codebase where you log in or register users. The tokens provide a way to authenticate a user or give access to a specific set of video/audio calls.
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
@@ -94,7 +94,7 @@ token = client.create_token("admin-user")
 
 You can create a call by providing the call type and an ID:
 
-- The [call type](call_types/builtin) controls which features are enabled, and sets up permissions.
+- The [call type](call_types/builtin) controls which features are enabled and sets up permissions.
 - Calls IDs can be reused, which means they can be joined multiple times, so it's possible to set up recurring calls.
 
 You can optionally restrict call access by providing a list of users.
@@ -192,7 +192,7 @@ curl -X PUT "https://video.stream-io-api.com/video/call/default/${CALL_ID}/membe
 
 ## Updating a call
 
-- Most of the call type settings can be overriden on a call level.
+- Most of the call type settings can be overridden on a call level.
 
 - Custom data can also be stored for calls.
 
@@ -293,7 +293,7 @@ curl -X POST "https://video.stream-io-api.com/video/call/default/${CALL_ID}/star
 </TabItem>
 </Tabs>
 
-Almost all livestream software and hardware supports RTMPS. Our API supports using a third-party software for streaming using RTMPS. For more information reference the [Streaming section](streaming/overview/).
+Almost all livestream software and hardware supports RTMPS. Our API supports using third-party software for streaming using RTMPS. For more information, reference the [Streaming section](streaming/overview/).
 
 The following example shows how to get the RTMP address that you need to provide for the third-party software:
 
@@ -303,7 +303,7 @@ The following example shows how to get the RTMP address that you need to provide
 
 Calls can be recorded for later use. Calls recording can be started/stopped via API calls or configured to start automatically when the first user joins the call.
 
-For more information see the [Recordings section](recording/calls/).
+For more information, see the [Recordings section](recording/calls/).
 
 The following example shows how to start and stop recording:
 

--- a/docusaurus/video/docusaurus/docs/api/basics/get_started.mdx
+++ b/docusaurus/video/docusaurus/docs/api/basics/get_started.mdx
@@ -8,6 +8,7 @@ title: Get started
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import RTMP from '../_common_/rtmp.mdx';
+import Broadcast from '../_common_/broadcast.mdx';
 
 For the average Stream integration, the development work focuses on code that executes in the client. However, some tasks must be executed from the server for safety (for example, token generation).
 
@@ -262,36 +263,7 @@ For more information see the [Streaming section](streaming/overview/).
 
 The following example shows how to start and stop HLS broadcasting:
 
-<Tabs groupId="examples">
-<TabItem value="js" label="JavaScript">
-
-```js
-call.startHLSBroadcasting();
-
-// to end broadcasting
-call.stopHLSBroadcasting();
-```
-
-</TabItem>
-<TabItem value="py" label="Python">
-
-```py
-call.start_broadcasting()
-
-// to end broadcasting
-call.stop_broadcasting()
-```
-
-</TabItem>
-<TabItem value="curl" label="cURL">
-
-```bash
-curl -X POST "https://video.stream-io-api.com/video/call/default/${CALL_ID}/start_broadcasting?api_key=${API_KEY}" \
--H "Authorization: ${JWT_TOKEN}"
-```
-
-</TabItem>
-</Tabs>
+<Broadcast />
 
 Almost all livestream software and hardware supports RTMPS. Our API supports using third-party software for streaming using RTMPS. For more information, reference the [Streaming section](streaming/overview/).
 

--- a/docusaurus/video/docusaurus/docs/api/basics/get_started.mdx
+++ b/docusaurus/video/docusaurus/docs/api/basics/get_started.mdx
@@ -78,10 +78,6 @@ const exp = Math.round(new Date().getTime() / 1000) + 60 * 60;
 const iat = Math.round(new Date().getTime() / 1000);
 
 client.createToken(userId, exp, iat);
-
-// optionally provide call cids
-const call_cids = ['default:call1', 'livestream:call2'];
-client.createToken(userId, exp, iat, call_cids);
 ```
 
 </TabItem>
@@ -251,7 +247,7 @@ curl -X PUT "https://video.stream-io-api.com/video/call/default/${CALL_ID}?api_k
 </TabItem>
 </Tabs>
 
-## Start HLS broadcasting
+## Streaming
 
 Broadcasting serves are a means of transmitting live or pre-recorded content to a wide audience.
 
@@ -263,6 +259,8 @@ We can choose from two approaches to broadcasting the media:
 It is up to the integrators to decide, what approach will be used in their apps for the audience to consume the streams.
 
 For more information see the [Streaming section](streaming/overview/).
+
+The following example shows how to start and stop HLS broadcasting:
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
@@ -295,17 +293,19 @@ curl -X POST "https://video.stream-io-api.com/video/call/default/${CALL_ID}/star
 </TabItem>
 </Tabs>
 
-## Set up a call for RTMP
-
 Almost all livestream software and hardware supports RTMPS. Our API supports using a third-party software for streaming using RTMPS. For more information reference the [Streaming section](streaming/overview/).
+
+The following example shows how to get the RTMP address that you need to provide for the third-party software:
 
 <RTMP />
 
-## Start call recording
+## Recording
 
 Calls can be recorded for later use. Calls recording can be started/stopped via API calls or configured to start automatically when the first user joins the call.
 
 For more information see the [Recordings section](recording/calls/).
+
+The following example shows how to start and stop recording:
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
@@ -338,7 +338,7 @@ curl -X POST "https://video.stream-io-api.com/video/call/default/${CALL_ID}/star
 </TabItem>
 </Tabs>
 
-## List recordings for a call
+The following example shows how to query existing recordings:
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">

--- a/docusaurus/video/docusaurus/docs/api/call_types/CustomStyle.jsx
+++ b/docusaurus/video/docusaurus/docs/api/call_types/CustomStyle.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+// Workaround for hiding SDK tutorial links on the call types shared page
+const css = `.theme-admonition {
+    display: none
+}`;
+
+const CustomStyle = () => <style>{css}</style>;
+
+export default CustomStyle;

--- a/docusaurus/video/docusaurus/docs/api/call_types/builtin_types.mdx
+++ b/docusaurus/video/docusaurus/docs/api/call_types/builtin_types.mdx
@@ -4,3 +4,9 @@ sidebar_position: 1
 slug: /call_types/builtin
 title: Built-in Types
 ---
+
+import CallTypesPage from '../../../shared/video/_call-types.md';
+import CustomStyle from './CustomStyle';
+
+<CustomStyle />
+<CallTypesPage />

--- a/docusaurus/video/docusaurus/docs/api/call_types/geofencing.mdx
+++ b/docusaurus/video/docusaurus/docs/api/call_types/geofencing.mdx
@@ -6,21 +6,20 @@ title: Geofencing
 ---
 
 With geofencing, you can define which edge nodes are utilized for video calls within specific geo-fenced areas.
-You can set geo-fences to a call type or specify when creating a new call. Multiple geo-fences can be used at the same time.
+You can set geofences to a call type or specify when creating a new call. Multiple geo-fences can be used at the same time.
 
+At this present, you can only select from a predefined list of geofences:
 
-At this present you can only select from a predefined list of geo-fences:
-
-| Name              | Description                                                                                                     |
-|-------------------|-----------------------------------------------------------------------------------------------------------------|
-| european_union    | The list of countries that are part of european union                                                           |
-| united_states     | Only selects edges in US                                                                                        |
-| canada            | Only selects edges in Canada                                                                                    |
-| united_kingdom    | Only selects edges in the United Kingdom                                                                        |
-| india             | Only selects edges in India                                                                                     |
-| china_exclusion   | Excludes edges running in mainland China (currently Stream edge infrastructure does not have any edge in China) |
-| russia_exclusion  | Excludes edges running in Russia                                                                                |
-| belarus_exclusion | Excludes edges running in Belarus                                                                               |
+| Name              | Description                                                                                                      |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------- |
+| european_union    | The list of countries that are part of european union                                                            |
+| united_states     | Only selects edges in US                                                                                         |
+| canada            | Only selects edges in Canada                                                                                     |
+| united_kingdom    | Only selects edges in the United Kingdom                                                                         |
+| india             | Only selects edges in India                                                                                      |
+| china_exclusion   | Excludes edges running in mainland China (currently, Stream edge infrastructure does not have any edge in China) |
+| russia_exclusion  | Excludes edges running in Russia                                                                                 |
+| belarus_exclusion | Excludes edges running in Belarus                                                                                |
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/docusaurus/video/docusaurus/docs/api/call_types/geofencing.mdx
+++ b/docusaurus/video/docusaurus/docs/api/call_types/geofencing.mdx
@@ -51,4 +51,29 @@ call.create({
 ```
 
 </TabItem>
+<TabItem value="py" label="Python">
+
+```py
+client.video.create_call_type(
+  name= '<call type name>',
+  settings= CallSettingsRequest(
+    geofencing= GeofenceSettingsRequest(
+      names= ['european_union'],
+    ),
+  ),
+)
+
+//override settings on call level
+call.create(
+  data = CallRequest(
+    created_by_id= 'john',
+    settings_override= CallSettingsRequest(
+      geofencing= GeofenceSettingsRequest(
+        names= ['european_union', 'united_states'],
+      ),
+  ),
+  ),
+)
+```
+</TabItem>
 </Tabs>

--- a/docusaurus/video/docusaurus/docs/api/call_types/manage-types.mdx
+++ b/docusaurus/video/docusaurus/docs/api/call_types/manage-types.mdx
@@ -21,6 +21,15 @@ client.getCallType({name: 'livestream'});
 ```
 
 </TabItem>
+<TabItem value="py" label="Python">
+
+```py
+client.video.list_call_types()
+
+//or
+client.get_call_type(name= 'livestream')
+```
+</TabItem>
 </Tabs>
 
 ## Create call type
@@ -46,6 +55,27 @@ client.video.createCallType({
 ```
 
 </TabItem>
+<TabItem value="py" label="Python">
+
+```py
+client.video.create_call_type(
+  name= 'allhands',
+  settings = CallSettingsRequest(
+    audio=AudioSettingsRequest( mic_default_on= True, default_device ='speaker' ),
+  ),
+  grants = {
+    "admin": [
+      OwnCapability.SEND_AUDIO.to_str(),
+      OwnCapability.SEND_VIDEO.to_str(),
+      OwnCapability.MUTE_USERS.to_str(),
+    ],
+    "user": [OwnCapability.SEND_AUDIO.to_str(), OwnCapability.SEND_VIDEO.to_str()],
+  },
+)
+
+```
+</TabItem>
+
 </Tabs>
 
 ## Update call type
@@ -62,6 +92,16 @@ client.video.updateCallType('allhands', {
 ```
 
 </TabItem>
+<TabItem value="py" label="Python">
+
+```py
+client.video.update_call_type(name='allhands', 
+  settings= CallSettingsRequest(
+    audio=AudioSettingsRequest( mic_default_on= False, default_device= 'earpiece' ),
+  ),
+)
+```
+</TabItem>
 </Tabs>
 
 ## Delete call type
@@ -73,5 +113,12 @@ client.video.updateCallType('allhands', {
 client.video.deleteCallType({name: 'allhands'});
 ```
 
+</TabItem>
+<TabItem value="py" label="Python">
+
+```py
+client.video.delete_call_type(name= 'allhands')
+
+```
 </TabItem>
 </Tabs>

--- a/docusaurus/video/docusaurus/docs/api/call_types/permissions.mdx
+++ b/docusaurus/video/docusaurus/docs/api/call_types/permissions.mdx
@@ -5,10 +5,18 @@ slug: /call_types/permissions
 title: Permissions
 ---
 
+import CallCapabilities from '../../../shared/video/_call-capabilities.md';
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-This page shows how you can create or update roles for a call type. For a conceptual overview about roles please see the [Permissions page](../../moderation/permissions/).
+## Introduction
+
+This page shows how you can create or update roles for a call type.
+
+Stream has a role-based permission system. Each user has an application level role, and also channel (chat product) and call (video product) level roles. Every role (be it application or call/channel level) contains a list of capabilities. A capability is an action (for example create call). The list of capabilities assigned to a role defines what a user is allowed to do. Call roles are defined on the call type level.
+
+## Configuring roles
 
 When you create a call type you can specify your role configurations. A role configuration consists of a role name and the list of capabilities that are enabled for that role.
 
@@ -47,3 +55,21 @@ client.video.updateCallType('default', {
 
 </TabItem>
 </Tabs>
+
+### Built-in roles
+
+There are 5 pre-defined call roles, these are:
+
+- `user`
+- `moderator`
+- `host`
+- `admin`
+- `call-member`
+
+You can access the default roles and their capabilities in your [Stream Dashboard](https://dashboard.getstream.io/).
+
+### Capabilities
+
+The list of call capabilities that you can include in your role configurations:
+
+<CallCapabilities />

--- a/docusaurus/video/docusaurus/docs/api/call_types/permissions.mdx
+++ b/docusaurus/video/docusaurus/docs/api/call_types/permissions.mdx
@@ -8,6 +8,16 @@ title: Permissions
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+This page shows how you can create or update roles for a call type. For a conceptual overview about roles please see the [Permissions page](../../moderation/permissions/).
+
+When you create a call type you can specify your role configurations. A role configuration consists of a role name and the list of capabilities that are enabled for that role.
+
+When you create a call type it comes with a default set of configuration. You can override or extend that.
+
+The following example overrides the capabilities of the built-in `admin` role, and defines the `customrole`.
+
+Please note that for the below code to work you need to create the `customrole` beforehand, you can do that in your [Stream Dashboard](https://dashboard.getstream.io/).
+
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
 
@@ -20,7 +30,17 @@ client.video.createCallType({
       VideoOwnCapability.SEND_VIDEO,
       VideoOwnCapability.MUTE_USERS,
     ],
-    user: [VideoOwnCapability.SEND_AUDIO, VideoOwnCapability.SEND_VIDEO],
+    ['customrole']: [
+      VideoOwnCapability.SEND_AUDIO,
+      VideoOwnCapability.SEND_VIDEO,
+    ],
+  },
+});
+
+// or edit a built-in call type
+client.video.updateCallType('default', {
+  grants: {
+    /* ... */
   },
 });
 ```

--- a/docusaurus/video/docusaurus/docs/api/call_types/permissions.mdx
+++ b/docusaurus/video/docusaurus/docs/api/call_types/permissions.mdx
@@ -14,17 +14,17 @@ import TabItem from '@theme/TabItem';
 
 This page shows how you can create or update roles for a call type.
 
-Stream has a role-based permission system. Each user has an application level role, and also channel (chat product) and call (video product) level roles. Every role (be it application or call/channel level) contains a list of capabilities. A capability is an action (for example create call). The list of capabilities assigned to a role defines what a user is allowed to do. Call roles are defined on the call type level.
+Stream has a role-based permission system. Each user has an application-level role, and also channel (chat product) and call (video product) level roles. Every role (be it application or call/channel level) contains a list of capabilities. A capability is an action (for example, create a call). The list of capabilities assigned to a role defines what a user is allowed to do. Call roles are defined on the call type level.
 
 ## Configuring roles
 
-When you create a call type you can specify your role configurations. A role configuration consists of a role name and the list of capabilities that are enabled for that role.
+When you create a call type, you can specify your role configurations. A role configuration consists of a role name and the list of capabilities that are enabled for that role.
 
-When you create a call type it comes with a default set of configuration. You can override or extend that.
+When you create a call type, it comes with a default set of configurations. You can override or extend that.
 
-The following example overrides the capabilities of the built-in `admin` role, and defines the `customrole`.
+The following example overrides the capabilities of the built-in `admin` role and defines the `customrole`.
 
-Please note that for the below code to work you need to create the `customrole` beforehand, you can do that in your [Stream Dashboard](https://dashboard.getstream.io/).
+Please note that for the below code to work, you need to create the `customrole` beforehand. You can do that in your [Stream Dashboard](https://dashboard.getstream.io/).
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">

--- a/docusaurus/video/docusaurus/docs/api/call_types/permissions.mdx
+++ b/docusaurus/video/docusaurus/docs/api/call_types/permissions.mdx
@@ -54,6 +54,32 @@ client.video.updateCallType('default', {
 ```
 
 </TabItem>
+
+<TabItem value="py" label="Python">
+
+```py
+client.video.create_call_type(
+  name= '<call type name>',
+  grants={
+    "admin": [
+      OwnCapability.SEND_AUDIO.to_str(),
+      OwnCapability.SEND_VIDEO.to_str(),
+      OwnCapability.MUTE_USERS.to_str(),
+    ],
+    "customrole": [
+      OwnCapability.SEND_AUDIO.to_str(),
+      OwnCapability.SEND_VIDEO.to_str(),
+    ],
+  },
+)
+
+client.video.update_call_type(name = 'default', 
+  grants= {
+    /* ... */
+  },
+)
+```
+</TabItem>
 </Tabs>
 
 ### Built-in roles

--- a/docusaurus/video/docusaurus/docs/api/call_types/settings.mdx
+++ b/docusaurus/video/docusaurus/docs/api/call_types/settings.mdx
@@ -5,17 +5,23 @@ slug: /call_types/settings
 title: Settings
 ---
 
+import CallTypeSettings from '../../../shared/video/_call-type-settings.md';
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-The Stream API provides multiple configuration options on the call type level. You can find the list of configuration options on the [built-in call types page](../../call_types/builtin#call-type-settings).
+## Configuration options
 
-This page shows code examples for these configurations.
+The Stream API provides multiple configuration options on the call type level.
+
+<CallTypeSettings />
 
 - You can provide the settings when creating or updating a call type
 - For maximum flexiblity you can ovverride the settings on the call-level when creating or updating a call
 
-## Settings
+## Code examples
+
+### Settings
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
@@ -47,7 +53,7 @@ call.create({
 </TabItem>
 </Tabs>
 
-## Notification settings
+### Notification settings
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">

--- a/docusaurus/video/docusaurus/docs/api/call_types/settings.mdx
+++ b/docusaurus/video/docusaurus/docs/api/call_types/settings.mdx
@@ -17,7 +17,7 @@ The Stream API provides multiple configuration options on the call type level.
 <CallTypeSettings />
 
 - You can provide the settings when creating or updating a call type
-- For maximum flexiblity you can ovverride the settings on the call-level when creating or updating a call
+- For maximum flexibility, you can override the settings on the call level when creating or updating a call
 
 ## Code examples
 

--- a/docusaurus/video/docusaurus/docs/api/call_types/settings.mdx
+++ b/docusaurus/video/docusaurus/docs/api/call_types/settings.mdx
@@ -8,6 +8,13 @@ title: Settings
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+The Stream API provides multiple configuration options on the call type level. You can find the list of configuration options on the [built-in call types page](../../call_types/builtin#call-type-settings).
+
+This page shows code examples for these configurations.
+
+- You can provide the settings when creating or updating a call type
+- For maximum flexiblity you can ovverride the settings on the call-level when creating or updating a call
+
 ## Settings
 
 <Tabs groupId="examples">

--- a/docusaurus/video/docusaurus/docs/api/call_types/settings.mdx
+++ b/docusaurus/video/docusaurus/docs/api/call_types/settings.mdx
@@ -51,6 +51,34 @@ call.create({
 ```
 
 </TabItem>
+
+<TabItem value="py" label="Python">
+
+```py
+client.video.create_call_type(
+  name= '<call type name>',
+  settings= CallSettingsRequest(
+    screensharing=ScreensharingSettingsRequest(
+      access_request_enabled= False,
+      enabled= True,
+    ),
+  ),
+)
+
+// override settings on call level
+call.create(
+  data=CallRequest(
+    created_by_id= 'john',
+    settings_override= CallSettingsRequest(
+      screensharing= ScreensharingSettingsRequest(
+        enabled= False,
+      ),
+    ),
+  ),
+)
+```
+</TabItem>
+
 </Tabs>
 
 ### Notification settings
@@ -77,4 +105,25 @@ client.video.createCallType({
 ```
 
 </TabItem>
+<TabItem value="py" label="Python">
+
+```py
+client.video.create_call_type(
+  name= '<call type name>',
+  notification_settings= NotificationSettingsRequest(
+    enabled= True,
+    call_notification= EventNotificationSettingsRequest(
+      apns=Apnsrequest(
+        title= '{{ user.display_name }} invites you to a call',
+      ),
+      enabled= True,
+    ),
+    session_started= EventNotificationSettingsRequest(
+      enabled: False,
+    ),
+  ),
+)
+```
+</TabItem>
+
 </Tabs>

--- a/docusaurus/video/docusaurus/docs/api/moderation/capabilities.mdx
+++ b/docusaurus/video/docusaurus/docs/api/moderation/capabilities.mdx
@@ -1,6 +1,0 @@
----
-id: moderation_capabilities
-sidebar_position: 2
-slug: /moderation/capabilities
-title: Capabilities
----

--- a/docusaurus/video/docusaurus/docs/api/moderation/overview.mdx
+++ b/docusaurus/video/docusaurus/docs/api/moderation/overview.mdx
@@ -5,6 +5,9 @@ slug: /moderation/overview
 title: Overview
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 When running calls with a larger audience, you’ll often need moderation features to prevent abuse. Participants can share inappropriate content via
 
 - The video feed
@@ -15,26 +18,29 @@ When running calls with a larger audience, you’ll often need moderation featur
 
 Stream has tools to help you manage these issues while on a call.
 
-
 ### Removing & Blocking a member from a call
 
 Call can be configured to only be accessible to their members. To remove a user from a call and prevent from accessing again:
 
 <Tabs groupId="examples">
-  <TabItem value="js" label="JavaScript">
+<TabItem value="js" label="JavaScript">
 
 ```js
-TODO: JS
+// Block user
+call.blockUser({ user_id: 'sara' });
+
+// Unblock user
+call.unblockUser({ user_id: 'sara' });
 ```
 
-  </TabItem>
-  <TabItem value="py" label="Python">
+</TabItem>
+<TabItem value="py" label="Python">
 
 ```py
 TODO: python
 ```
 
-  </TabItem>
+</TabItem>
 </Tabs>
 
 ### Call permissions
@@ -42,61 +48,72 @@ TODO: python
 You can configure if a screen share is enabled, disabled or requires requesting permission
 
 <Tabs groupId="examples">
-  <TabItem value="js" label="JavaScript">
+<TabItem value="js" label="JavaScript">
 
-    ```js
-    TODO: JS
-    ```
+```js
+call.update({
+  settings_override: {
+    screensharing: { enabled: true, access_request_enabled: true },
+  },
+});
+```
 
-  </TabItem>
-  <TabItem value="py" label="Python">
+</TabItem>
+<TabItem value="py" label="Python">
 
-    ```py
-    TODO: python
-    ```
+```py
+TODO: python
+```
 
-  </TabItem>
+</TabItem>
 </Tabs>
-
 
 ### Muting everyone
 
 You can also mute every other participant’s video or audio.
 
-
 <Tabs groupId="examples">
-  <TabItem value="js" label="JavaScript">
+<TabItem value="js" label="JavaScript">
 
-    ```js
-    TODO: JS
-    ```
+```js
+// You can specify which kind of stream(s) to mute
+call.muteUsers({
+  mute_all_users: true,
+  audio: true,
+});
+```
 
-  </TabItem>
-  <TabItem value="py" label="Python">
+</TabItem>
+<TabItem value="py" label="Python">
 
-    ```py
-    TODO: python
-    ```
+```py
+TODO: python
+```
 
-  </TabItem>
+</TabItem>
 </Tabs>
 
 ### Muting one participant's video or audio (or both)
 
-
 <Tabs groupId="examples">
-  <TabItem value="js" label="JavaScript">
+<TabItem value="js" label="JavaScript">
 
-    ```js
-    TODO: JS
-    ```
+```js
+call.muteUsers({
+  user_ids: ['sara'],
+  audio: true,
+  video: true,
+  screenshare: true,
+  screenshare_audio: true,
+});
+```
 
-  </TabItem>
-  <TabItem value="py" label="Python">
+</TabItem>
+<TabItem value="py" label="Python">
 
-    ```py
-    TODO: python
-    ```
+```py
+TODO: python
+```
 
-  </TabItem>
+</TabItem>
 </Tabs>

--- a/docusaurus/video/docusaurus/docs/api/moderation/overview.mdx
+++ b/docusaurus/video/docusaurus/docs/api/moderation/overview.mdx
@@ -1,0 +1,102 @@
+---
+id: moderation_index
+sidebar_position: 1
+slug: /moderation/overview
+title: Overview
+---
+
+When running calls with a larger audience, you’ll often need moderation features to prevent abuse. Participants can share inappropriate content via
+
+- The video feed
+- Audio
+- Screen share
+- Chat messages
+- Username
+
+Stream has tools to help you manage these issues while on a call.
+
+
+### Removing & Blocking a member from a call
+
+Call can be configured to only be accessible to their members. To remove a user from a call and prevent from accessing again:
+
+<Tabs groupId="examples">
+  <TabItem value="js" label="JavaScript">
+
+```js
+TODO: JS
+```
+
+  </TabItem>
+  <TabItem value="py" label="Python">
+
+```py
+TODO: python
+```
+
+  </TabItem>
+</Tabs>
+
+### Call permissions
+
+You can configure if a screen share is enabled, disabled or requires requesting permission
+
+<Tabs groupId="examples">
+  <TabItem value="js" label="JavaScript">
+
+    ```js
+    TODO: JS
+    ```
+
+  </TabItem>
+  <TabItem value="py" label="Python">
+
+    ```py
+    TODO: python
+    ```
+
+  </TabItem>
+</Tabs>
+
+
+### Muting everyone
+
+You can also mute every other participant’s video or audio.
+
+
+<Tabs groupId="examples">
+  <TabItem value="js" label="JavaScript">
+
+    ```js
+    TODO: JS
+    ```
+
+  </TabItem>
+  <TabItem value="py" label="Python">
+
+    ```py
+    TODO: python
+    ```
+
+  </TabItem>
+</Tabs>
+
+### Muting one participant's video or audio (or both)
+
+
+<Tabs groupId="examples">
+  <TabItem value="js" label="JavaScript">
+
+    ```js
+    TODO: JS
+    ```
+
+  </TabItem>
+  <TabItem value="py" label="Python">
+
+    ```py
+    TODO: python
+    ```
+
+  </TabItem>
+</Tabs>

--- a/docusaurus/video/docusaurus/docs/api/moderation/overview.mdx
+++ b/docusaurus/video/docusaurus/docs/api/moderation/overview.mdx
@@ -117,3 +117,63 @@ TODO: python
 
 </TabItem>
 </Tabs>
+
+### Granting and revoking permissions
+
+It's possible for users to ask for any of the following permissions:
+
+- Sending audio
+- Sending video
+- Sharing their screen
+
+These requests will trigger the `call.permission_request` webhook.
+
+This is how these requests can be accepted:
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+call.updateUserPermissions({
+  user_id: 'sara',
+  grant_permissions: [VideoOwnCapability.SEND_AUDIO],
+});
+```
+
+</TabItem>
+<TabItem value="py" label="Python">
+
+```py
+TODO: python
+```
+
+</TabItem>
+</Tabs>
+
+For moderation purposes any user's permission to
+
+- send audio
+- send video
+- share their screen
+
+can be revoked at any time. This is how it can be done:
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+call.updateUserPermissions({
+  user_id: 'sara',
+  revoke_permissions: [VideoOwnCapability.SEND_AUDIO],
+});
+```
+
+</TabItem>
+<TabItem value="py" label="Python">
+
+```py
+TODO: python
+```
+
+</TabItem>
+</Tabs>

--- a/docusaurus/video/docusaurus/docs/api/moderation/overview.mdx
+++ b/docusaurus/video/docusaurus/docs/api/moderation/overview.mdx
@@ -37,7 +37,11 @@ call.unblockUser({ user_id: 'sara' });
 <TabItem value="py" label="Python">
 
 ```py
-TODO: python
+// Block user
+call.block_user( user_id='sara' )
+
+// Unblock user
+call.unblock_user( user_id= 'sara' )
 ```
 
 </TabItem>
@@ -62,7 +66,11 @@ call.update({
 <TabItem value="py" label="Python">
 
 ```py
-TODO: python
+call.update(
+  settings_override = CallSettingsRequest(
+    screensharing= ScreensharingSettingsRequest( enabled= True, access_request_enabled= True ),
+  ),
+)
 ```
 
 </TabItem>
@@ -87,7 +95,11 @@ call.muteUsers({
 <TabItem value="py" label="Python">
 
 ```py
-TODO: python
+// You can specify which kind of stream(s) to mute
+call.mute_users(
+  mute_all_users= True,
+  audio=True,
+)
 ```
 
 </TabItem>
@@ -112,7 +124,13 @@ call.muteUsers({
 <TabItem value="py" label="Python">
 
 ```py
-TODO: python
+call.mute_users(
+  user_ids= ['sara'],
+  audio= True,
+  video= True,
+  screenshare= True,
+  screenshare_audio = True,
+)
 ```
 
 </TabItem>
@@ -144,7 +162,10 @@ call.updateUserPermissions({
 <TabItem value="py" label="Python">
 
 ```py
-TODO: python
+call.update_user_permissions(
+  user_id= 'sara',
+  grant_permissions= [OwnCapability.SEND_AUDIO.to_str()],
+)
 ```
 
 </TabItem>
@@ -172,7 +193,10 @@ call.updateUserPermissions({
 <TabItem value="py" label="Python">
 
 ```py
-TODO: python
+call.update_user_permissions(
+  user_id= 'sara',
+  revoke_permissions= [OwnCapability.SEND_AUDIO.to_str()],
+)
 ```
 
 </TabItem>

--- a/docusaurus/video/docusaurus/docs/api/moderation/permissions.mdx
+++ b/docusaurus/video/docusaurus/docs/api/moderation/permissions.mdx
@@ -4,29 +4,3 @@ sidebar_position: 1
 slug: /moderation/permissions
 title: Permissions
 ---
-
-Stream has a role-based permission system. Each user has an application level role, and also channel (chat product) and call (video product) level roles.
-
-Every role (be it application or call/channel level) contains a list of capabilities. A capability is an action (for example create call). The list of capabilities assigned to a role defines what a user is allowed to do.
-
-This page focuses on call-level roles.
-
-## Video capabilities
-
-The list of [video capabilities](../../call_types/builtin/#default-call-capabilities) are available on the Call Types page.
-
-## Call roles
-
-Every user that has access to a call has a call-level role assigned to them. Users can have different roles for different calls (for example a user can be a host in one call, and a viewer in another).
-
-### Built-in roles
-
-Call roles are defined on the call type level. Every [built-in call type](../../call_types/builtin/) comes with a default set of roles set up to match their use-case (a livestreaming app requeires different roles than an audio room). You can customize these roles, for a code example see the [call types settings page](../../call_types/permissions).
-
-It's also possible to customize the roles in your [Stream Dashboard](https://dashboard.getstream.io/).
-
-### Custom roles
-
-It's also possible to define your own custom roles to extend the built-in call types, or when [creating your own call types](../../call_types/manage). For a code example see the [call types settings page](../../call_types/permissions).
-
-You can also create your own roles in your [Stream Dashboard](https://dashboard.getstream.io/).

--- a/docusaurus/video/docusaurus/docs/api/moderation/permissions.mdx
+++ b/docusaurus/video/docusaurus/docs/api/moderation/permissions.mdx
@@ -1,6 +1,0 @@
----
-id: moderation_permissions
-sidebar_position: 1
-slug: /moderation/permissions
-title: Permissions
----

--- a/docusaurus/video/docusaurus/docs/api/moderation/permissions.mdx
+++ b/docusaurus/video/docusaurus/docs/api/moderation/permissions.mdx
@@ -4,3 +4,29 @@ sidebar_position: 1
 slug: /moderation/permissions
 title: Permissions
 ---
+
+Stream has a role-based permission system. Each user has an application level role, and also channel (chat product) and call (video product) level roles.
+
+Every role (be it application or call/channel level) contains a list of capabilities. A capability is an action (for example create call). The list of capabilities assigned to a role defines what a user is allowed to do.
+
+This page focuses on call-level roles.
+
+## Video capabilities
+
+The list of [video capabilities](../../call_types/builtin/#default-call-capabilities) are available on the Call Types page.
+
+## Call roles
+
+Every user that has access to a call has a call-level role assigned to them. Users can have different roles for different calls (for example a user can be a host in one call, and a viewer in another).
+
+### Built-in roles
+
+Call roles are defined on the call type level. Every [built-in call type](../../call_types/builtin/) comes with a default set of roles set up to match their use-case (a livestreaming app requeires different roles than an audio room). You can customize these roles, for a code example see the [call types settings page](../../call_types/permissions).
+
+It's also possible to customize the roles in your [Stream Dashboard](https://dashboard.getstream.io/).
+
+### Custom roles
+
+It's also possible to define your own custom roles to extend the built-in call types, or when [creating your own call types](../../call_types/manage). For a code example see the [call types settings page](../../call_types/permissions).
+
+You can also create your own roles in your [Stream Dashboard](https://dashboard.getstream.io/).

--- a/docusaurus/video/docusaurus/docs/api/recording/recording_calls.mdx
+++ b/docusaurus/video/docusaurus/docs/api/recording/recording_calls.mdx
@@ -151,52 +151,52 @@ call.update({
 
 ```py
 # Disable on call level
-call.update_call(UpdateCallRequest(
+call.update(
     settings_override=CallSettingsRequest(
         recording=RecordSettingsRequest(
             mode='disabled',
         ),
     ),
-))
+)
 
 # Disable on call type level
 call_type_name = 'default'
-call.update_call_type(call_type_name, UpdateCallTypeRequest(
+client.video.update_call_type(call_type_name,
     settings=CallSettingsRequest(
         recording=RecordSettingsRequest(
             mode='disabled',
         ),
     ),
-))
+)
 
 # Automatically record calls
-call.update_call_type(UpdateCallTypeRequest(
+client.video.update_call_type(
     settings=CallSettingsRequest(
         recording=RecordSettingsRequest(
             mode='auto',
         ),
     ),
-))
+)
 
 # Enable
-call.update_call(UpdateCallRequest(
+client.update(
     settings_override=CallSettingsRequest(
         recording=RecordSettingsRequest(
             mode='available',
         ),
     ),
-))
+)
 
 
 # Other settings
-call.update_call(UpdateCallRequest(
+call.update(
     settings_override=CallSettingsRequest(
         recording=RecordSettingsRequest(
             mode='available',
             quality='1080p',
         ),
     ),
-))
+)
 ```
 
 </TabItem>
@@ -226,14 +226,14 @@ call.update({
 
 ```py
 # Enable recording
-call.update_call(UpdateCallRequest(
+call.update(
     settings_override=CallSettingsRequest(
         recording=RecordSettingsRequest(
             mode='available',
             audio_only=True
         ),
     ),
-))
+)
 ```
 
 </TabItem>

--- a/docusaurus/video/docusaurus/docs/api/recording/recording_calls.mdx
+++ b/docusaurus/video/docusaurus/docs/api/recording/recording_calls.mdx
@@ -331,8 +331,34 @@ client.video.updateCallType(callTypeName, {
 <TabItem value="py" label="Python">
 
 ```py
-def hello_world():
-    print("Hello, world!")
+layout_options = {
+        'logo.image_url':
+        'https://theme.zdassets.com/theme_assets/9442057/efc3820e436f9150bc8cf34267fff4df052a1f9c.png',
+        'logo.horizontal_position': 'center',
+        'title.text': 'Building Stream Video Q&A',
+        'title.horizontal_position': 'center',
+        'title.color': 'black',
+        'participant_label.border_radius': '0px',
+        'participant.border_radius': '0px',
+        'layout.spotlight.participants_bar_position': 'top',
+        'layout.background_color': '#f2f2f2',
+        'participant.placeholder_background_color': '#1f1f1f',
+        'layout.single-participant.padding_inline': '20%',
+        'participant_label.background_color': 'transparent',
+    }
+
+    client.video.update_call_type(CALL_TYPE_NAME, settings=CallSettingsRequest(
+        recording=RecordSettingsRequest(
+            mode='available',
+            audio_only=False,
+            quality='1080p',
+            layout=LayoutSettingsRequest(
+                name='spotlight',
+                options=layout_options,
+            ),
+        ),
+    ),
+    )
 ```
 
 </TabItem>
@@ -459,8 +485,18 @@ client.video.updateCallType(callTypeName, {
 <TabItem value="py" label="Python">
 
 ```py
-def hello_world():
-    print("Hello, world!")
+client.video.update_call_type(CALL_TYPE_NAME, settings=CallSettingsRequest(
+        recording=RecordSettingsRequest(
+            mode="available",
+            audio_only=False,
+            quality="1080p",
+            layout=LayoutSettingsRequest(
+                name="spotlight",
+                external_css_url='https://path/to/custom.css',
+            ),
+        ),
+    ),
+    )
 ```
 
 </TabItem>
@@ -495,8 +531,18 @@ client.video.updateCallType(callTypeName, {
 <TabItem value="py" label="Python">
 
 ```py
-def hello_world():
-    print("Hello, world!")
+client.video.update_call_type(CALL_TYPE_NAME, settings=CallSettingsRequest(
+        recording=RecordSettingsRequest(
+            mode="available",
+            audio_only=False,
+            quality="1080p",
+            layout=LayoutSettingsRequest(
+                name="custom",
+                external_app_url='https://path/to/layout/app',
+            ),
+        ),
+    ),
+    )
 ```
 
 </TabItem>

--- a/docusaurus/video/docusaurus/docs/api/recording/recording_calls.mdx
+++ b/docusaurus/video/docusaurus/docs/api/recording/recording_calls.mdx
@@ -9,11 +9,11 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 Calls can be recorded for later use. Calls recording can be started/stopped via API calls or configured to start automatically when the first user joins the call.
-Call recording is done by Stream server-side and later stored on AWS S3, you can also configure your Stream application to have files stored on your own S3 bucket (in that case storage costs will not apply).
+Call recording is done by Stream server-side and later stored on AWS S3. You can also configure your Stream application to have files stored on your own S3 bucket (in that case, storage costs will not apply).
 
-By default, calls will be recorded as mp4 video files, you can configure recording to only capture the audio.
+By default, calls will be recorded as mp4 video files. You can configure recording to only capture the audio.
 
-Note: by default recordings contain all tracks mixed in a single file, you can follow the discussion [here](https://github.com/GetStream/protocol/discussions/247) if you are interested in different ways to record calls.
+Note: by default, recordings contain all tracks mixed in a single file. You can follow the discussion [here](https://github.com/GetStream/protocol/discussions/247) if you are interested in different ways to record calls.
 
 ## Start and stop call recording
 
@@ -244,14 +244,14 @@ call.update(
 Recording can be customized in several ways:
 
 - You can pick one of the built-in layouts and pass some options to it
-- You can customize more in detail the style of the call by providing your own CSS file
+- You can further customize the style of the call by providing your own CSS file
 - You can use your own recording application
 
 There are three available layouts you can use for your calls: `"single_participant"`, `"grid"` and `"spotlight"`
 
 ### Single Participant
 
-This layout shows only one participant video at the time, other video tracks are hidden.
+This layout shows only one participant video at a time, other video tracks are hidden.
 
 <img
   src={require('../assets/layout_single-participant.png').default}
@@ -267,7 +267,7 @@ The visible video is selected based on this priority:
 
 ### Grid
 
-This layout shows a configurable number of tracks in a equally sized grid.
+This layout shows a configurable number of tracks in an equally sized grid.
 
 <img
   src={require('../assets/layout_grid.png').default}
@@ -285,7 +285,7 @@ This layout shows a video in a spotlight and the rest of the participants in a s
 
 ## Layout options
 
-Each layout has a number of options that you can configure, here is an example:
+Each layout has a number of options that you can configure. Here is an example:
 
 <img
   src={require('../assets/layout_custom_options.png').default}
@@ -401,40 +401,40 @@ Here you can find the complete list of options available to each layout.
 
 ### Grid
 
-| Option                                   | Type    | Default     | Allowed Values                        | Description                                                                                                                                                                                          |
-| ---------------------------------------- | ------- | ----------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| logo.image_url                           | string  | ``          |                                       | add a logo image to the video layout                                                                                                                                                                 |
-| logo.vertical_position                   | string  | `top`       | `[top bottom center]`                 | vertical position of the logo                                                                                                                                                                        |
-| participant.label_horizontal_position    | string  | `left`      | `[center left right]`                 | horizontal position for the participant label                                                                                                                                                        |
-| participant.placeholder_background_color | color   | `#000000`   |                                       | Sets the background color for video placeholder tile                                                                                                                                                 |
-| video.scale_mode                         | string  | `fill`      | `[fit fill]`                          | How source video is displayed inside a box when aspect ratio does not match. 'fill' crops the video to fill the entire box, 'fit' ensures the video fits inside the box by padding necessary padding |
-| logo.horizontal_position                 | string  | `center`    | `[center left right]`                 | horizontal position of the logo                                                                                                                                                                      |
-| participant.video_border_rounded         | boolean | `true`      |                                       | Render the participant video border rounded                                                                                                                                                          |
-| participant.label_display_border         | boolean | `true`      |                                       | Render label border                                                                                                                                                                                  |
-| participant.label_border_color           | color   | `#CCCCCC`   |                                       | Label border color                                                                                                                                                                                   |
-| grid.cell_padding                        | size    | `10`        |                                       | padding between cells                                                                                                                                                                                |
-| video.screenshare_scale_mode             | string  | `fit`       | `[fit fill]`                          | How source video is displayed inside a box when aspect ratio does not match. 'fill' crops the video to fill the entire box, 'fit' ensures the video fits inside the box by padding necessary padding |
-| video.background_color                   | color   | `#000000`   |                                       | The background color                                                                                                                                                                                 |
-| participant.label_border_radius          | number  | `1.2`       |                                       | The corner radius used for the label border                                                                                                                                                          |
-| grid.size_percentage                     | number  | `90`        |                                       | The percentage of the screen the grid should take up                                                                                                                                                 |
-| grid.margin                              | size    | `10`        |                                       | the margin between grid and spotlight                                                                                                                                                                |
-| grid.columns                             | number  | `5`         |                                       | how many column to use in grid mode                                                                                                                                                                  |
-| participant.label_vertical_position      | string  | `bottom`    | `[top bottom center]`                 | vertical position for the participant label                                                                                                                                                          |
-| participant.label_display                | boolean | `true`      |                                       | Show the participant label                                                                                                                                                                           |
-| participant.video_border_color           | color   | `#CCCCCC`   |                                       | The color used for the participant video border                                                                                                                                                      |
-| participant.video_border_width           | boolean | `true`      |                                       | The stroke width used to render a participant border                                                                                                                                                 |
-| screenshare_layout                       | string  | `spotlight` | `[grid spotlight single-participant]` | The layout to use when entering screenshare mode                                                                                                                                                     |
-| participant.label_text_color             | color   | `#000000`   |                                       | Text color of the participant label                                                                                                                                                                  |
-| participant.label_background_color       | color   | `#00000000` |                                       | Background color of the participant label                                                                                                                                                            |
-| participant.label_border_rounded         | boolean | `true`      |                                       | Render the label border rounded                                                                                                                                                                      |
-| participant.video_border_radius          | number  | `1.2`       |                                       | The corner radius used for the participant video border                                                                                                                                              |
-| participant.video_highlight_border_color | color   | `#7CFC00`   |                                       | The color used for highlighted participants video border                                                                                                                                             |
-| grid.rows                                | number  | `4`         |                                       | how many rows to use in grid mode                                                                                                                                                                    |
+| Option                                   | Type    | Default     | Allowed Values                        | Description                                                                                                                                                                                              |
+| ---------------------------------------- | ------- | ----------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| logo.image_url                           | string  | ``          |                                       | add a logo image to the video layout                                                                                                                                                                     |
+| logo.vertical_position                   | string  | `top`       | `[top bottom center]`                 | vertical position of the logo                                                                                                                                                                            |
+| participant.label_horizontal_position    | string  | `left`      | `[center left right]`                 | horizontal position for the participant label                                                                                                                                                            |
+| participant.placeholder_background_color | color   | `#000000`   |                                       | Sets the background color for video placeholder tile                                                                                                                                                     |
+| video.scale_mode                         | string  | `fill`      | `[fit fill]`                          | How source video is displayed inside a box when the aspect ratio does not match. 'fill' crops the video to fill the entire box, 'fit' ensures the video fits inside the box by padding necessary padding |
+| logo.horizontal_position                 | string  | `center`    | `[center left right]`                 | horizontal position of the logo                                                                                                                                                                          |
+| participant.video_border_rounded         | boolean | `true`      |                                       | Render the participant video border rounded                                                                                                                                                              |
+| participant.label_display_border         | boolean | `true`      |                                       | Render label border                                                                                                                                                                                      |
+| participant.label_border_color           | color   | `#CCCCCC`   |                                       | Label border color                                                                                                                                                                                       |
+| grid.cell_padding                        | size    | `10`        |                                       | padding between cells                                                                                                                                                                                    |
+| video.screenshare_scale_mode             | string  | `fit`       | `[fit fill]`                          | How source video is displayed inside a box when the aspect ratio does not match. 'fill' crops the video to fill the entire box, 'fit' ensures the video fits inside the box by padding necessary padding |
+| video.background_color                   | color   | `#000000`   |                                       | The background color                                                                                                                                                                                     |
+| participant.label_border_radius          | number  | `1.2`       |                                       | The corner radius used for the label border                                                                                                                                                              |
+| grid.size_percentage                     | number  | `90`        |                                       | The percentage of the screen the grid should take up                                                                                                                                                     |
+| grid.margin                              | size    | `10`        |                                       | the margin between grid and spotlight                                                                                                                                                                    |
+| grid.columns                             | number  | `5`         |                                       | how many column to use in grid mode                                                                                                                                                                      |
+| participant.label_vertical_position      | string  | `bottom`    | `[top bottom center]`                 | vertical position for the participant label                                                                                                                                                              |
+| participant.label_display                | boolean | `true`      |                                       | Show the participant label                                                                                                                                                                               |
+| participant.video_border_color           | color   | `#CCCCCC`   |                                       | The color used for the participant video border                                                                                                                                                          |
+| participant.video_border_width           | boolean | `true`      |                                       | The stroke width used to render a participant border                                                                                                                                                     |
+| screenshare_layout                       | string  | `spotlight` | `[grid spotlight single-participant]` | The layout to use when entering screen share mode                                                                                                                                                        |
+| participant.label_text_color             | color   | `#000000`   |                                       | Text color of the participant label                                                                                                                                                                      |
+| participant.label_background_color       | color   | `#00000000` |                                       | Background color of the participant label                                                                                                                                                                |
+| participant.label_border_rounded         | boolean | `true`      |                                       | Render the label border rounded                                                                                                                                                                          |
+| participant.video_border_radius          | number  | `1.2`       |                                       | The corner radius used for the participant video border                                                                                                                                                  |
+| participant.video_highlight_border_color | color   | `#7CFC00`   |                                       | The color used for highlighted participants video border                                                                                                                                                 |
+| grid.rows                                | number  | `4`         |                                       | how many rows to use in grid mode                                                                                                                                                                        |
 
 ## Custom recording styling using external CSS
 
-You can customize how recorded calls look like by providing an external CSS file, the CSS file needs to be publicly available and ideally hosted on a CDN to ensure best performance.
-The best way to find the right CSS setup is by running the layout app directly, the application is [publicly available on Github here](https://github.com/GetStream/stream-video-js/tree/main/sample-apps/react/egress-composite) and contains instructions on how to be used.
+You can customize how recorded calls look by providing an external CSS file. The CSS file needs to be publicly available and ideally hosted on a CDN to ensure the best performance.
+The best way to find the right CSS setup is by running the layout app directly. The application is [publicly available on Github here](https://github.com/GetStream/stream-video-js/tree/main/sample-apps/react/egress-composite) and contains instructions on how to be used.
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
@@ -470,7 +470,7 @@ def hello_world():
 
 If needed, you can use your own custom application to record a call. This is the most flexible and complex approach to record calls, make sure to reach out to our customer support before going with this approach.
 
-The layout app used to record calls is available on Github and is a good starting point, the repository also includes information on how to build your own.
+The layout app used to record calls is available on GitHub and is a good starting point. The repository also includes information on how to build your own.
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
@@ -504,4 +504,4 @@ def hello_world():
 
 ## Client-side recording
 
-Unfortunately there is no direct support for client-side recording at the moment. Call recording at the moment is done by Stream server-side. If client-side recording is important for you please make sure to follow the conversation [here](https://github.com/GetStream/protocol/discussions/249).
+Unfortunately, there is no direct support for client-side recording at the moment. Call recording at the moment is done by Stream server-side. If client-side recording is important for you please make sure to follow the conversation [here](https://github.com/GetStream/protocol/discussions/249).

--- a/docusaurus/video/docusaurus/docs/api/streaming/backstage.mdx
+++ b/docusaurus/video/docusaurus/docs/api/streaming/backstage.mdx
@@ -7,11 +7,16 @@ title: Backstage
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import GoLive from '../_common_/go_live.mdx'
+import GoLive from '../_common_/go_live.mdx';
 
 ## Introduction
 
+By default livestreams are created in backstage mode, when in backstage mode streams can only be accessed by admin-like users.
+This is necessary because it makes it possible to create the setup in advance and to notify and grant access to viewers when the event starts.
+
 ## Configuration
+
+You change the backstage mode settings on the call type or on the call level.
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
@@ -63,7 +68,11 @@ client.video.update_call_type(
 </TabItem>
 </Tabs>
 
+Setting the backstage mode to `false` means that calls won't be created in backstage mode, and anyone can join the call.
+
 ## Backstage Permissions
+
+When a call is in backstage mode only users with the `join-backstage` capability are allowed to join.
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
@@ -89,11 +98,21 @@ client.video.update_call_type(
 </TabItem>
 </Tabs>
 
+With this approach you can add multiple members that have the `join-backstage` capability, which allows you to have multiple hosts.
+
 ## Go Live
+
+When the hosts are ready to start the stream and allow viewers to join you can call the `GoLive` method.
+
+Optionally you can start HLS broadcast and/or recording at the same time as going live.
 
 <GoLive />
 
 ## Stop Live
+
+When the stream ends the `StopLive` endpoint will remove the viewers that are still in the call, and prevent from new viewers to join.
+
+A call can enter and leave backstage mode multiple times.
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">

--- a/docusaurus/video/docusaurus/docs/api/streaming/backstage.mdx
+++ b/docusaurus/video/docusaurus/docs/api/streaming/backstage.mdx
@@ -41,7 +41,7 @@ client.video.updateCallType('<call type name>', {
 
 ```py
 # call level update
-call.update_call(
+call.update(
     settings_override=CallSettingsRequest(
         backstage=BackstageSettingsRequest(
             enabled=True,
@@ -51,7 +51,7 @@ call.update_call(
 
 # call type level update
 call_type_name = '<call type name>'
-call.update_call_type(
+client.video.update_call_type(
     settings=CallSettingsRequest(
         backstage=BackstageSettingsRequest(
             enabled=True,
@@ -81,7 +81,7 @@ client.video.updateCallType('<call type name>', {
 
 ```py
 callTypeName = '<call type name>'
-call.update_call_type(
+client.video.update_call_type(
     grants={"host": [OwnCapability.JOIN_BACKSTAGE.to_str()]},
 )
 ```

--- a/docusaurus/video/docusaurus/docs/api/streaming/backstage.mdx
+++ b/docusaurus/video/docusaurus/docs/api/streaming/backstage.mdx
@@ -11,7 +11,7 @@ import GoLive from '../_common_/go_live.mdx';
 
 ## Introduction
 
-By default livestreams are created in backstage mode, when in backstage mode streams can only be accessed by admin-like users.
+By default, livestreams are created in backstage mode, while in backstage mode, streams can only be accessed by admin-like users.
 This is necessary because it makes it possible to create the setup in advance and to notify and grant access to viewers when the event starts.
 
 ## Configuration
@@ -72,7 +72,7 @@ Setting the backstage mode to `false` means that calls won't be created in backs
 
 ## Backstage Permissions
 
-When a call is in backstage mode only users with the `join-backstage` capability are allowed to join.
+When a call is in backstage mode, only users with the `join-backstage` capability are allowed to join.
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
@@ -102,9 +102,9 @@ With this approach you can add multiple members that have the `join-backstage` c
 
 ## Go Live
 
-When the hosts are ready to start the stream and allow viewers to join you can call the `GoLive` method.
+When the hosts are ready to start the stream and allow viewers to join, you can call the `GoLive` method.
 
-Optionally you can start HLS broadcast and/or recording at the same time as going live.
+Optionally, you can start the HLS broadcast and/or recording at the same time as going live.
 
 <GoLive />
 

--- a/docusaurus/video/docusaurus/docs/api/streaming/hls.mdx
+++ b/docusaurus/video/docusaurus/docs/api/streaming/hls.mdx
@@ -52,6 +52,7 @@ These events are sent to users connected to the call and your webhook/SQS:
 
 - `call.broadcasting_started`
 - `call.broadcasting_stopped`
+- `call.broadcasting_failed`
 
 ## Consuming HLS broadcast
 

--- a/docusaurus/video/docusaurus/docs/api/streaming/hls.mdx
+++ b/docusaurus/video/docusaurus/docs/api/streaming/hls.mdx
@@ -4,3 +4,5 @@ sidebar_position: 2
 slug: /streaming/hls
 title: HLS
 ---
+
+[HLS streaming](https://en.wikipedia.org/wiki/HTTP_Live_Streaming) provides better buffering than WebRTC, at the cost having a slight delay in your livestreams.

--- a/docusaurus/video/docusaurus/docs/api/streaming/hls.mdx
+++ b/docusaurus/video/docusaurus/docs/api/streaming/hls.mdx
@@ -5,8 +5,65 @@ slug: /streaming/hls
 title: HLS
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 import Broadcast from '../_common_/broadcast.mdx';
+import GoLive from '../_common_/go_live.mdx';
 
 [HLS streaming](https://en.wikipedia.org/wiki/HTTP_Live_Streaming) provides better buffering than WebRTC, at the cost having a slight delay in your livestreams.
 
+## Start and stop HLS broadcast
+
+There are two ways to start/stop HLS broadcast:
+
 <Broadcast />
+
+Or, if you're using backstage mode, you can do that when going live:
+
+<GoLive />
+
+Once the live ended, the HLS broadcast will be stopped as well.
+
+## User permissions
+
+To perform these operations, users need the following capabilities:
+
+- `start-broadcast-call`
+- `stop-broadcast-call`
+
+## Broadcast state
+
+You can check if the call is being broadcasted like this:
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+const resp = await call.getOrCreate();
+const isBroadcasting = resp.call.egress.broadcasting;
+```
+
+</TabItem>
+</Tabs>
+
+## Events
+
+These events are sent to users connected to the call and your webhook/SQS:
+
+- `call.broadcasting_started`
+- `call.broadcasting_stopped`
+
+## Consuming HLS broadcast
+
+Users don't need to join the call to consume the HLS broadcast, but they need to have the URL of the broadcast:
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+const resp = await call.getOrCreate();
+const URL = resp.call.egress.hls?.playlist_url;
+```
+
+</TabItem>
+</Tabs>

--- a/docusaurus/video/docusaurus/docs/api/streaming/hls.mdx
+++ b/docusaurus/video/docusaurus/docs/api/streaming/hls.mdx
@@ -5,4 +5,8 @@ slug: /streaming/hls
 title: HLS
 ---
 
+import Broadcast from '../_common_/broadcast.mdx';
+
 [HLS streaming](https://en.wikipedia.org/wiki/HTTP_Live_Streaming) provides better buffering than WebRTC, at the cost having a slight delay in your livestreams.
+
+<Broadcast />

--- a/docusaurus/video/docusaurus/docs/api/streaming/hls.mdx
+++ b/docusaurus/video/docusaurus/docs/api/streaming/hls.mdx
@@ -44,6 +44,13 @@ const isBroadcasting = resp.call.egress.broadcasting;
 ```
 
 </TabItem>
+<TabItem value="py" label="Python">
+
+```py
+resp = call.get()
+isBroadcasting = resp.data().call.egress.broadcasting
+```
+</TabItem>
 </Tabs>
 
 ## Events
@@ -66,5 +73,12 @@ const resp = await call.getOrCreate();
 const URL = resp.call.egress.hls?.playlist_url;
 ```
 
+</TabItem>
+<TabItem value="py" label="Python">
+
+```py
+resp = call.get()
+URL = resp.data().call.egress.hls.playlist_url
+```
 </TabItem>
 </Tabs>

--- a/docusaurus/video/docusaurus/docs/api/streaming/overview.mdx
+++ b/docusaurus/video/docusaurus/docs/api/streaming/overview.mdx
@@ -44,6 +44,8 @@ const response = await call.getOrCreate({
 </TabItem>
 </Tabs>
 
+### Set the call live
+
 By default livestreams are created in backstage mode, when in backstage mode streams can only be accessed by admin-like users.
 This is necessary because it makes it possible to create the setup in advance and to notify and grant access to viewers when the event starts.
 
@@ -51,13 +53,13 @@ All we need to do in this case is call the `GoLive` method on the call object an
 
 <GoLive />
 
-### Create a simple test app using the livestream video player
+### Test watching the stream
 
-TODO: point to a simple webapp where you can run our video player, OK to use something like Codesanbox
+For testing purposes you can use this [simple example application](https://codesandbox.io/s/javascript-livestream-viewer-lwzgmw) that can play WebRTC and HLS streams.
 
 ### Test sending video using WebRTC
 
-You can refer to this [CodeSandbox](https://codesandbox.io/s/livestream-tutorial-mlqtrd?file=/src/App.tsx) - where you can send videos via WebRTC
+For testing purposes you can use this [simple example host application](https://codesandbox.io/s/javascript-livestream-host-3hs4vt).
 
 ### Test sending video via RTMP using OBS
 
@@ -65,26 +67,14 @@ Let's keep the demo app open and try to send video to the same call using RTMP.
 
 #### Log the URL & Stream Key
 
-​
-
 <RTMP />
 
 #### Open OBS and go to settings -> stream
 
-​
 Select "custom" service
 Server: equal to the rtmpURL from the log
 Stream key: equal to the streamKey from the log
 
 Press start streaming in OBS. The RTMP stream will now show up in your call just like a regular video participant.
 
-Now that we've learned to publish using WebRTC or RTMP let's talk about watching the livestream.
-
-### Set the call live
-
-Until now we connected to the call as the host user. By default livestream calls are configured to only allow hosts to send audio/video tracks.
-Viewers on the other hand are not
-
-```
-// TODO: ...
-```
+You can test the livestream with the test application linked above.

--- a/docusaurus/video/docusaurus/docs/api/streaming/overview.mdx
+++ b/docusaurus/video/docusaurus/docs/api/streaming/overview.mdx
@@ -43,6 +43,19 @@ const response = await call.getOrCreate({
 ```
 
 </TabItem>
+<TabItem value="py" label="Python">
+
+```py
+call = client.video.call('livestream', callId)
+response = call.create(
+  data= CallRequest(
+    created_by_id= 'john',
+    // You can add multiple hosts if you want to
+    members= [MemberRequest( user_id= 'john', role= 'host' )],
+  ),
+)
+```
+</TabItem>
 </Tabs>
 
 The built-in `livestream` call type has sensible defaults for livestreaming. However, you can customize that call type or create your own to better match your requirements. More information on this topic can be found in the [Call Types section](../../call_types/builtin).

--- a/docusaurus/video/docusaurus/docs/api/streaming/overview.mdx
+++ b/docusaurus/video/docusaurus/docs/api/streaming/overview.mdx
@@ -90,3 +90,7 @@ Press start streaming in OBS. The RTMP stream will now show up in your call just
 You can test the livestream with the test application linked above.
 
 For more information on this topic see the [RTMP page](../rtmp).
+
+## Recording
+
+Liverstreams (and any others calls) can be recorded for later use, for more information see the [Recording section](../../recording/calls).

--- a/docusaurus/video/docusaurus/docs/api/streaming/overview.mdx
+++ b/docusaurus/video/docusaurus/docs/api/streaming/overview.mdx
@@ -73,6 +73,8 @@ For testing purposes, you can use this [simple example host application](https:/
 
 ### Test sending video via RTMP using OBS
 
+Almost all livestream software and hardware supports RTMP. Our API supports using third-party software for streaming using RTMP.
+
 Let's keep the demo app open and try to send video to the same call using RTMP.
 
 #### Log the URL & Stream Key

--- a/docusaurus/video/docusaurus/docs/api/streaming/overview.mdx
+++ b/docusaurus/video/docusaurus/docs/api/streaming/overview.mdx
@@ -11,9 +11,9 @@ import TabItem from '@theme/TabItem';
 import GoLive from '../_common_/go_live.mdx';
 import RTMP from '../_common_/rtmp.mdx';
 
-In this section we are going to explain how you can use Stream to power different livestream use-cases.
+In this section, we are going to explain how you can use Stream to power different livestream use cases.
 
-Stream video allows you to power ultra low-latency streaming (hundreds of milliseconds). This is made possible by our worldwide edge infrastructure which support WebRTC for consuming and sending video.
+Stream video allows you to power ultra-low-latency streaming (hundreds of milliseconds). This is made possible by our worldwide edge infrastructure, which supports WebRTC for consuming and sending video.
 
 Other important features related to livestream that are discussed in this section:
 
@@ -45,31 +45,31 @@ const response = await call.getOrCreate({
 </TabItem>
 </Tabs>
 
-The built-in `livestream` call type has sensible defaults for livestreaming. However you can customize that call type, or create your own to better match your requirements. More information on this topic can be found in the [Call Types section](../../call_types/builtin).
+The built-in `livestream` call type has sensible defaults for livestreaming. However, you can customize that call type or create your own to better match your requirements. More information on this topic can be found in the [Call Types section](../../call_types/builtin).
 
 ### Set the call live
 
-By default livestreams are created in backstage mode, when in backstage mode streams can only be accessed by admin-like users.
+By default, livestreams are created in backstage mode. When in backstage mode, streams can only be accessed by admin-like users.
 This is necessary because it makes it possible to create the setup in advance and to notify and grant access to viewers when the event starts.
 
-All we need to do in this case is call the `GoLive` method on the call object and that will make it accessible to viewers.
+All we need to do in this case is call the `GoLive` method on the call object, and that will make it accessible to viewers.
 
 <GoLive />
 
-For more information see the [Backstage page](../backstage).
+For more information, see the [Backstage page](../backstage).
 
 ### Test watching the stream
 
-The Stream API supports two different kind of streams:
+The Stream API supports two different kinds of streams:
 
 - [WebRTC](../webrtc)
 - [HLS](../hls)
 
-For testing purposes you can use this [simple example application](https://codesandbox.io/s/javascript-livestream-viewer-lwzgmw) that can play WebRTC and HLS streams as well. Don't forget to provide the necessary credentials before testing.
+For testing purposes, you can use this [simple example application](https://codesandbox.io/s/javascript-livestream-viewer-lwzgmw) that can play WebRTC and HLS streams as well. Don't forget to provide the necessary credentials before testing.
 
 ### Test sending video via WebRTC
 
-For testing purposes you can use this [simple example host application](https://codesandbox.io/s/javascript-livestream-host-3hs4vt). You can open the application multiple times which allows you to have multiple hosts, who can send multiple audio/video streams. Don't forget to provide the necessary credentials before testing.
+For testing purposes, you can use this [simple example host application](https://codesandbox.io/s/javascript-livestream-host-3hs4vt). You can open the application multiple times which allows you to have multiple hosts, who can send multiple audio/video streams. Don't forget to provide the necessary credentials before testing.
 
 ### Test sending video via RTMP using OBS
 
@@ -89,8 +89,8 @@ Press start streaming in OBS. The RTMP stream will now show up in your call just
 
 You can test the livestream with the test application linked above.
 
-For more information on this topic see the [RTMP page](../rtmp).
+For more information on this topic, see the [RTMP page](../rtmp).
 
 ## Recording
 
-Liverstreams (and any others calls) can be recorded for later use, for more information see the [Recording section](../../recording/calls).
+Liverstreams (and any other calls) can be recorded for later use. For more information see the [Recording section](../../recording/calls).

--- a/docusaurus/video/docusaurus/docs/api/streaming/overview.mdx
+++ b/docusaurus/video/docusaurus/docs/api/streaming/overview.mdx
@@ -36,6 +36,7 @@ call = client.video.call('livestream', callId);
 const response = await call.getOrCreate({
   data: {
     created_by_id: 'john',
+    // You can add multiple hosts if you want to
     members: [{ user_id: 'john', role: 'host' }],
   },
 });
@@ -43,6 +44,8 @@ const response = await call.getOrCreate({
 
 </TabItem>
 </Tabs>
+
+The built-in `livestream` call type has sensible defaults for livestreaming. However you can customize that call type, or create your own to better match your requirements. More information on this topic can be found in the [Call Types section](../../call_types/builtin).
 
 ### Set the call live
 
@@ -53,13 +56,20 @@ All we need to do in this case is call the `GoLive` method on the call object an
 
 <GoLive />
 
+For more information see the [Backstage page](../backstage).
+
 ### Test watching the stream
 
-For testing purposes you can use this [simple example application](https://codesandbox.io/s/javascript-livestream-viewer-lwzgmw) that can play WebRTC and HLS streams.
+The Stream API supports two different kind of streams:
 
-### Test sending video using WebRTC
+- [WebRTC](../webrtc)
+- [HLS](../hls)
 
-For testing purposes you can use this [simple example host application](https://codesandbox.io/s/javascript-livestream-host-3hs4vt).
+For testing purposes you can use this [simple example application](https://codesandbox.io/s/javascript-livestream-viewer-lwzgmw) that can play WebRTC and HLS streams as well. Don't forget to provide the necessary credentials before testing.
+
+### Test sending video via WebRTC
+
+For testing purposes you can use this [simple example host application](https://codesandbox.io/s/javascript-livestream-host-3hs4vt). You can open the application multiple times which allows you to have multiple hosts, who can send multiple audio/video streams. Don't forget to provide the necessary credentials before testing.
 
 ### Test sending video via RTMP using OBS
 
@@ -78,3 +88,5 @@ Stream key: equal to the streamKey from the log
 Press start streaming in OBS. The RTMP stream will now show up in your call just like a regular video participant.
 
 You can test the livestream with the test application linked above.
+
+For more information on this topic see the [RTMP page](../rtmp).

--- a/docusaurus/video/docusaurus/docs/api/streaming/rtmp.mdx
+++ b/docusaurus/video/docusaurus/docs/api/streaming/rtmp.mdx
@@ -31,9 +31,8 @@ const address = resp.call.ingress.rtmp.address.replace(
 <TabItem value="py" label="Python">
 
 ```py
-
 # create or get the call
-response = call.get_or_create_call(
+response = call.create(
     data=CallRequest(
         created_by_id='john'
     )

--- a/docusaurus/video/docusaurus/docs/api/streaming/rtmp.mdx
+++ b/docusaurus/video/docusaurus/docs/api/streaming/rtmp.mdx
@@ -10,7 +10,11 @@ import TabItem from '@theme/TabItem';
 
 ## RTMP support overview
 
+Almost all livestream software and hardware supports RTMP. Our API supports using third-party software for streaming using RTMP.
+
 ## RTMP publishing
+
+This is how you can acquire the necessary information for publishing RTMP using a third-party software.
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
@@ -49,4 +53,6 @@ address = response.data().call.ingress.rtmp.address.replace('<your_token_here>',
 </TabItem>
 </Tabs>
 
-## RTMP relay
+The user(s) streaming from the third-party software will show up as regular users in the call.
+
+You can see an example in the [Quickstart](../../streaming/overview/#test-sending-video-via-rtmp-using-obs).

--- a/docusaurus/video/docusaurus/docs/api/streaming/webrtc.mdx
+++ b/docusaurus/video/docusaurus/docs/api/streaming/webrtc.mdx
@@ -5,4 +5,4 @@ slug: /streaming/webrtc
 title: WebRTC
 ---
 
-## Low-latency streaming with WebRTC
+[WebRTC](https://webrtc.org/) allows you to have low-latency streaming (hundreds of milliseconds).

--- a/docusaurus/video/docusaurus/docs/api/streaming/webrtc.mdx
+++ b/docusaurus/video/docusaurus/docs/api/streaming/webrtc.mdx
@@ -7,12 +7,10 @@ title: WebRTC
 
 [WebRTC](https://webrtc.org/) allows you to have low-latency streaming (hundreds of milliseconds).
 
-To set up WebRTC-based streaming, your viewers must join the call. Once they join the call, they can access the video and audio streams that are published in the call.
+## Start and stop WebRTC broadcast
 
-## Users
+The WebRTC broadcast is always on. Viewers can access it by joining the call. You can control who can join the call with [backstage mode](../../streaming/backstage).
 
-You can use regular, guest or anonymous users to join the livestream. It's also possible to create call tokens that only allow access for specific calls. For more information, see the [authentication page](../../authentication).
+## Consuming WebRTC broadcast
 
-## Permissions
-
-The built-in `livestream` call type comes with sensible default permissions. However, if you create your own call type, you should make sure that the role you assign to viewers has the proper configuration (for example it restricts sending audio/video).
+Your viewers must join the call to access the stream. You can use regular, guest or anonymous users to join the livestream. It's also possible to create call tokens that only allow access for specific calls. For more information, see the [authentication page](../../authentication).

--- a/docusaurus/video/docusaurus/docs/api/streaming/webrtc.mdx
+++ b/docusaurus/video/docusaurus/docs/api/streaming/webrtc.mdx
@@ -6,3 +6,13 @@ title: WebRTC
 ---
 
 [WebRTC](https://webrtc.org/) allows you to have low-latency streaming (hundreds of milliseconds).
+
+To set up WebRTC-based streaming, your viewers must join the call. Once they join the call, they can access the video and audio streams that are published in the call.
+
+## Users
+
+You can use regular, guest or anonymous users to join the livestream. It's also possible to create call tokens that only allow access for specific calls. For more information, see the [authentication page](../../authentication).
+
+## Permissions
+
+The built-in `livestream` call type comes with sensible default permissions. However, if you create your own call type, you should make sure that the role you assign to viewers has the proper configuration (for example it restricts sending audio/video).

--- a/docusaurus/video/docusaurus/docs/api/webhooks/events.mdx
+++ b/docusaurus/video/docusaurus/docs/api/webhooks/events.mdx
@@ -9,9 +9,11 @@ Here you can find the list of events are sent to Webhook and SQS.
 
 | Event Type                      | Description                                       |
 |---------------------------------|---------------------------------------------------|
+| custom                          | Sent when a custom event is triggered             |
 | call.accepted                   | Sent when a user accepts an incoming call         |
 | call.blocked_user               | Sent when a user is blocked                       |
 | call.broadcasting_started       | Sent when HLS broadcasting has started            |
+| call.broadcasting_failed        | Sent when HLS broadcasting has failed             |
 | call.broadcasting_stopped       | Sent when HLS broadcasting is stopped             |
 | call.created                    | Sent when a call is created                       |
 | call.ended                      | Sent when a call is marked as ended               |
@@ -23,14 +25,15 @@ Here you can find the list of events are sent to Webhook and SQS.
 | call.permission_request         | Sent when a user requests access on a call        |
 | call.permissions_updated        | Sent when permissions are updated on a call       |
 | call.reaction_new               | Sent when a reaction is sent on a call            |
-| call.recording_started          | Sent when call recording starts                   |
-| call.recording_stopped          | Sent when call recording is stopped               |
 | call.rejected                   | Sent when a user rejects an incoming call         |
 | call.session_ended              | Sent when the session has ended                   |
 | call.session_participant_joined | Sent when a user joins a call                     |
 | call.session_participant_left   | Sent when a user leaves a call                    |
 | call.session_started            | Sent when a call session starts                   |
 | call.unblocked_user             | Sent when a user is unblocked                     |
+| call.user_muted                 | Sent when a call member is muted                  |
+| call.ring                       | Sent when a user rings others to join a call      |
+| call.notification               | Sent when a user notifies others to join a call   |
 | call.updated                    | Sent when a call is updated                       |
 | call.recording_started          | Sent when call recording has started              |
 | call.recording_stopped          | Sent when call recording has stopped              |


### PR DESCRIPTION
⚠️ This PR needs to be merged first: https://github.com/GetStream/stream-chat-docusaurus-cli/pull/115 ✅

For local testing: use the latest `staging` from `stream-chat-docusaurus-cli`

- [ ] Python examples: full review and gaps [@Sacha](https://getstream.slack.com/team/U01MAHX2A68)
- [x] Get started, move RTMP, recording, HLS to their own section [@Zita Szupera](https://getstream.slack.com/team/U02CA8MV9D1)
- [x] Get started, remove call token examples (not all customers will use this)
- [x] Call types section: improve docs [@Zita Szupera](https://getstream.slack.com/team/U02CA8MV9D1)
- [X] Geofencing: add explainer  [@Tommaso Barbugli](https://getstream.slack.com/team/U02U7SJP4)
- [x] Permissions: add explainer [@Zita Szupera](https://getstream.slack.com/team/U02CA8MV9D1)
- [x] Settings: add explainer [@Zita Szupera](https://getstream.slack.com/team/U02CA8MV9D1)
- [x] Moderation docs: add outline @tbarbugli 
- [x] Moderation docs: Python examples @sachaarbonel 
- [x] Moderation docs: Node examples @szuperaz
- [x] Streaming: go_live examples should also include hls and recording params - Node [@Zita Szupera](https://getstream.slack.com/team/U02CA8MV9D1)
- [x] Streaming: go_live examples should also include hls and recording params - Python [@Sacha](https://getstream.slack.com/team/U01MAHX2A68)
- [x] Livestreaming section: fill gaps [@Zita Szupera](https://getstream.slack.com/team/U02CA8MV9D1) -> I've added what I know, but HLS, WebRTC and RTMP pages need more explanation
- [x] Webhooks: make sure the list is in sync [@Sacha](https://getstream.slack.com/team/U01MAHX2A68)
- [x] Create separate method for call tokens, set `iat` by default - Node Zita 
- [x] Create separate method for call tokens and update examples - Python Sacha
- [x] HLS page Python examples - Sacha