### PR TITLE
Update readme for api docs local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ To generate code for your language, do this:
    - `language`: language to generate code for can be `ts`, `dart` or `swift`
    - `output_dir` is a directory where you want to put generated code in
 
-
 ## Generate sdk with docker
+
 For TS
+
 ```bash
 docker run -v $(pwd):/local ghcr.io/getstream/protobuf-generate ts /local/packages/client/src/gen
 
@@ -79,6 +80,7 @@ docker run --platform=linux/amd64 -v $(pwd):/local ghcr.io/getstream/protobuf-ge
 ```
 
 For Dart
+
 ```bash
 docker run -v $(pwd):/local ghcr.io/getstream/protobuf-generate dart /local/dart-sdk
 
@@ -97,3 +99,9 @@ docker run -v $(pwd):/local ghcr.io/getstream/protobuf-generate dart /local/dart
 # or
 docker run --platform=linux/amd64 -v $(pwd):/local ghcr.io/getstream/protobuf-generate dart /local/dart-sdk --branch=my-branch
 ```
+
+## Video API and server-side SDK documentation
+
+This repository hosts the [API and server-side SDK documentation](https://getstream.io/video/docs/api/) for video.
+
+For more info please see [the nested readme file](./docusaurus/video/docusaurus/README.md)

--- a/docusaurus/video/docusaurus/README.md
+++ b/docusaurus/video/docusaurus/README.md
@@ -2,26 +2,22 @@
 
 To work on the docs you need to first get the cli tool to build docs:
 
-- Make sure you have nvm installed and that you use node 16
-- Clone the GetStream/stream-chat-docusaurus-cli repo
-- Switch to the staging branch
-- Make sure to run `nvm use 16`
-- Run `yarn install`
-- Run `npm install -g` to get `stream-docusaurus-cli` in npm binaries cache
+- checkout the [`stream-chat-docusaurus-cli` repository](https://github.com/GetStream/stream-chat-docusaurus-cli)
+- follow the install steps in the [readme](https://github.com/GetStream/stream-chat-docusaurus-cli/tree/production?tab=readme-ov-file#installing)
 
 ### Running docs server
 
 - make sure to cd the `docusaurus/video` path of this repo
-- `nvm use 16` otherwise you get stupid node errors
-- `npx stream-chat-docusaurus -s` starts a developer server 
+- `npx stream-chat-docusaurus -s` starts a developer server
 
 ### Basic stuff
 
 - documentation sections are paths under docs/api
 - documentation is inside mdx files, that's a fancy extension of Markdown
 - mdx files must contain the intro section (the --- bit) otherwise they will not get picked up by the server
-- for code examples you can use `Tabs` and `TabItem`, see here for [more](https://docusaurus.io/docs/markdown-features/code-blocks#multi-language-support-code-blocks) 
+- for code examples you can use `Tabs` and `TabItem`, see here for [more](https://docusaurus.io/docs/markdown-features/code-blocks#multi-language-support-code-blocks)
 
 ### Other Notes
+
 - code examples with tabs are super dumb, you need to take into account that MDX is crap (indentation new lines will break the parser and lead to errors)
-- the development server does not support all sorts of reload, really often if a page breaks you need to ctrl-c and restart it 
+- the development server does not support all sorts of reload, really often if a page breaks you need to ctrl-c and restart it


### PR DESCRIPTION
- Link stream-chat-docusaurus-cli install steps instead of duplicating them
- Remove restriction for node version (the issue has been resolved in stream-chat-docusaurus-cli a while ago)
- Add info about docs in the top-level readme file
- Some reformats caused by my IDE