### PR TITLE
fix: Remove broken link for node token provider example

### DIFF
--- a/docusaurus/video/docusaurus/docs/api/basics/authentication.mdx
+++ b/docusaurus/video/docusaurus/docs/api/basics/authentication.mdx
@@ -247,8 +247,6 @@ def create_user_token(request):
 
 You need to provide the generated tokens to the client SDKs. Stream SDKs accept a token provider, that can be called to retrieve and renew tokens. You need to implement the token provider in your own application, this is usually an HTTP endpoint.
 
-Example [token provider for the Node SDK using Express](https://codesandbox.io/p/sandbox/stream-node-token-provider-example-f9cl27).
-
 ## Call tokens
 
 Call tokens contain a list of call IDs. If a user is authenticated with a call token, they can only access the specified calls. They are helpful if you want to limit call access, but you want to avoid managing call members (an example: a pay-pre-view link for livestreams, with hundreds of thousands of expected viewers).


### PR DESCRIPTION
Context: https://getstream.slack.com/archives/CP32GBDAA/p1708434046073949