### PR TITLE
docs: update cURL examples

### DIFF
--- a/docusaurus/video/docusaurus/docs/api/_common_/broadcast.mdx
+++ b/docusaurus/video/docusaurus/docs/api/_common_/broadcast.mdx
@@ -25,7 +25,9 @@ call.stop_broadcasting()
 <TabItem value="curl" label="cURL">
 
 ```bash
-curl -X POST "https://video.stream-io-api.com/video/call/default/${CALL_ID}/start_broadcasting?api_key=${API_KEY}" -H "Authorization: ${JWT_TOKEN}" -H "stream-auth-type: jwt"
+curl -X POST "https://video.stream-io-api.com/video/call/${CALL_TYPE}/${CALL_ID}/start_broadcasting?api_key=${API_KEY}" \
+     -H "Authorization: ${JWT_TOKEN}" \
+     -H "stream-auth-type: jwt"
 ```
 
 </TabItem>

--- a/docusaurus/video/docusaurus/docs/api/_common_/create-call.mdx
+++ b/docusaurus/video/docusaurus/docs/api/_common_/create-call.mdx
@@ -68,16 +68,18 @@ response = call.create(
 <TabItem value="curl" label="cURL">
 
 ```bash
-curl -X POST "https://video.stream-io-api.com/video/call/default/${CALL_ID}?api_key=${API_KEY}" \
+curl -X POST "https://video.stream-io-api.com/video/call/${CALL_TYPE}/${CALL_ID}?api_key=${API_KEY}" \
 -H "Content-Type: application/json" \
 -H "Authorization: ${JWT_TOKEN}" \
 -H "stream-auth-type: jwt" \
 -d '{
   "data": {
     "created_by_id": "sacha@getstream.io",
-    "settings_override": { "audio": { "access_request_enabled": false } }
-  },
-  "members": [ { "role": "speaker", "user_id": "sacha@getstream.io" } ]
+    "members": [
+      { "role": "speaker", "user_id": "sacha@getstream.io" }
+    ],
+    "custom": { "color": "blue" }
+  }
 }'
 ```
 

--- a/docusaurus/video/docusaurus/docs/api/recording/recording_calls.mdx
+++ b/docusaurus/video/docusaurus/docs/api/recording/recording_calls.mdx
@@ -5,6 +5,7 @@ slug: /recording/calls
 title: Recording calls
 ---
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -43,9 +44,13 @@ call.stop_recording()
 <TabItem value="curl" label="cURL">
 
 ```bash
-curl -X POST "https://video.stream-io-api.com/video/call/default/${CALL_ID}/start_recording?api_key=${API_KEY}" -H "Authorization: ${JWT_TOKEN}" -H "stream-auth-type: jwt"
+curl -X POST "https://video.stream-io-api.com/video/call/${CALL_TYPE}/${CALL_ID}/start_recording?api_key=${API_KEY}" \
+     -H "Authorization: ${JWT_TOKEN}" \
+     -H "stream-auth-type: jwt"
 
-curl -X POST "https://video.stream-io-api.com/video/call/default/${CALL_ID}/stop_recording?api_key=${API_KEY}" -H "Authorization: ${JWT_TOKEN}" -H "stream-auth-type: jwt"
+curl -X POST "https://video.stream-io-api.com/video/call/${CALL_TYPE}/${CALL_ID}/stop_recording?api_key=${API_KEY}" \
+     -H "Authorization: ${JWT_TOKEN}" \
+     -H "stream-auth-type: jwt"
 ```
 
 </TabItem>
@@ -73,7 +78,9 @@ call.list_recordings()
 <TabItem value="curl" label="cURL">
 
 ```bash
-curl -X GET "https://video.stream-io-api.com/video/call/default/${CALL_ID}/recordings?api_key=${API_KEY}" -H "Authorization: ${JWT_TOKEN}" -H "stream-auth-type: jwt"
+curl -X GET "https://video.stream-io-api.com/video/call/${CALL_TYPE}/${CALL_ID}/recordings?api_key=${API_KEY}" \
+     -H "Authorization: ${JWT_TOKEN}" \
+     -H "stream-auth-type: jwt"
 ```
 
 </TabItem>


### PR DESCRIPTION
### Overview

A customer pointed out that the cURL example for creating a call was wrong. I've fixed it in this PR and also took the opportunity to check the remaining cURL examples.

We should probably add the missing cURL examples across all sections, as it seems that now we only have JS and Python examples.