### PR TITLE
Update token examples for Bash

### DIFF
--- a/docusaurus/video/docusaurus/docs/api/basics/authentication.mdx
+++ b/docusaurus/video/docusaurus/docs/api/basics/authentication.mdx
@@ -354,13 +354,13 @@ def create_user_token(request):
 <TabItem value="bash" label="Bash">
 
 ```bash
-HEADER=$(echo -n '{"alg": "HS256", "typ": "JWT"}' | base64);
+HEADER=$(echo -n '{"alg": "HS256", "typ": "JWT"}' | openssl base64 -e -A | tr '+/' '-_' | tr -d '=');
 USER_ID='<user id>';
 CURRENT_TIMESTAMP=$(date +%s);
 HOUR_FROM_NOW=$((CURRENT_TIMESTAMP + 3600))
-PAYLOAD=$(echo -n '{"user_id": "'${USER_ID}'", "iat": '${CURRENT_TIMESTAMP}', "exp": '${HOUR_FROM_NOW}'}' | base64);
+PAYLOAD=$(echo -n '{"user_id": "'${USER_ID}'", "iat": '${CURRENT_TIMESTAMP}', "exp": '${HOUR_FROM_NOW}'}' | openssl base64 -e -A | tr '+/' '-_' | tr -d '=');
 SECRET='<API secret>';
-SIGNATURE=$(echo -n ${HEADER}.${PAYLOAD} | openssl dgst -sha256 -hmac ${SECRET} -binary | base64 | tr -d '=');
+SIGNATURE=$(echo -n ${HEADER}.${PAYLOAD} | openssl dgst -sha256 -hmac ${SECRET} -binary | openssl base64 -e -A | tr '+/' '-_' | tr -d '=');
 
 echo "${HEADER}.${PAYLOAD}.${SIGNATURE}"
 ```
@@ -406,15 +406,15 @@ client.create_call_token(user_id=user_id, expiration=exp, call_cids=call_cids)
 <TabItem value="bash" label="Bash">
 
 ```bash
-HEADER=$(echo -n '{"alg": "HS256", "typ": "JWT"}' | base64);
+HEADER=$(echo -n '{"alg": "HS256", "typ": "JWT"}' | openssl base64 -e -A | tr '+/' '-_' | tr -d '=');
 USER_ID='<user id>';
 CURRENT_TIMESTAMP=$(date +%s);
 HOUR_FROM_NOW=$((CURRENT_TIMESTAMP + 3600))
 CALL_CID1='livestream:1';
 CALL_CID2='livestream:2';
-PAYLOAD=$(echo -n '{"user_id": "'${USER_ID}'", "call_cids": ["'${CALL_CID1}'", "'${CALL_CID2}'"], "iat": '${CURRENT_TIMESTAMP}', "exp": '${HOUR_FROM_NOW}'}' | base64);
+PAYLOAD=$(echo -n '{"user_id": "'${USER_ID}'", "call_cids": ["'${CALL_CID1}'", "'${CALL_CID2}'"], "iat": '${CURRENT_TIMESTAMP}', "exp": '${HOUR_FROM_NOW}'}' | openssl base64 -e -A | tr '+/' '-_' | tr -d '=');
 SECRET='<API secret>';
-SIGNATURE=$(echo -n ${HEADER}.${PAYLOAD} | openssl dgst -sha256 -hmac ${SECRET} -binary | base64 | tr -d '=');
+SIGNATURE=$(echo -n ${HEADER}.${PAYLOAD} | openssl dgst -sha256 -hmac ${SECRET} -binary | openssl base64 -e -A | tr '+/' '-_' | tr -d '=');
 
 echo "${HEADER}.${PAYLOAD}.${SIGNATURE}"
 ```

--- a/docusaurus/video/docusaurus/docs/api/basics/get_started.mdx
+++ b/docusaurus/video/docusaurus/docs/api/basics/get_started.mdx
@@ -82,6 +82,25 @@ client = Stream(api_key="your_api_key", api_secret="your_api_secret", timeout=3.
 ```
 
 </TabItem>
+<TabItem value="bash" label="Bash">
+
+```bash
+# Create a server token
+HEADER=$(echo -n '{"alg": "HS256", "typ": "JWT"}' | openssl base64 -e -A | tr '+/' '-_' | tr -d '=');
+PAYLOAD=$(echo -n '{"server": true}' | openssl base64 -e -A | tr '+/' '-_' | tr -d '=');
+SECRET='<API secret>';
+SIGNATURE=$(echo -n ${HEADER}.${PAYLOAD} | openssl dgst -sha256 -hmac ${SECRET} -binary | openssl base64 -e -A | tr '+/' '-_' | tr -d '=');
+
+TOKEN="${HEADER}.${PAYLOAD}.${SIGNATURE}";
+API_KEY='<API key>';
+
+# Provide API key, token and auth header to all requests
+curl -X GET "https://video.stream-io-api.com/api/v2/app?api_key=${API_KEY}" \
+  -H "Authorization: ${TOKEN}" \
+  -H "stream-auth-type: jwt"
+```
+
+</TabItem>
 </Tabs>
 
 ## Creating users and user tokens


### PR DESCRIPTION
- Add an example to show how to create server tokens
- Fix the user tokens example (my test app had auth checks disabled, so I didn't catch an error in my testing)