### PR TITLE
fix: user type name in JS docs

### DIFF
--- a/docusaurus/video/docusaurus/docs/api/basics/authentication.mdx
+++ b/docusaurus/video/docusaurus/docs/api/basics/authentication.mdx
@@ -22,7 +22,7 @@ You can provide additional data for the user object using the `custom` field.
 <TabItem value="js" label="JavaScript">
 
 ```js
-const newUser: UserObjectRequest = {
+const newUser: UserRequest = {
   id: 'userid',
   role: 'user',
   custom: {
@@ -92,7 +92,7 @@ There are two ways to update user objects:
 <TabItem value="js" label="JavaScript">
 
 ```js
-const user: UserObjectRequest = {
+const user: UserRequest = {
   id: 'userid',
   role: 'user',
   custom: {

--- a/docusaurus/video/docusaurus/docs/api/basics/get_started.mdx
+++ b/docusaurus/video/docusaurus/docs/api/basics/get_started.mdx
@@ -115,7 +115,7 @@ Tokens need to be generated server-side. Typically, you integrate this into the 
 
 ```js
 const userId = 'john';
-const newUser: UserObjectRequest = {
+const newUser: UserRequest = {
   id: userId,
   role: 'user',
   custom: {


### PR DESCRIPTION
User type name was changed recently, and I forgot to update the docs, this fixes that issue.