### PR TITLE
docs(transcriptions): remove misleading information

### DIFF
--- a/docusaurus/video/docusaurus/docs/api/transcription/transcribing_calls.mdx
+++ b/docusaurus/video/docusaurus/docs/api/transcription/transcribing_calls.mdx
@@ -6,7 +6,6 @@ title: Call Transcriptions
 ---
 
 
-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/docusaurus/video/docusaurus/docs/api/transcription/transcribing_calls.mdx
+++ b/docusaurus/video/docusaurus/docs/api/transcription/transcribing_calls.mdx
@@ -6,6 +6,7 @@ title: Call Transcriptions
 ---
 
 
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -440,7 +441,7 @@ When using out of the box, transcriptions are optimized for calls with english s
 
 Please note: the call transcription feature does not perform any language translation. When you select a different language, the transcription process will simply improve the speech-to-text detection for that language.
 
-You can set the transcription languages in two ways: either as a call setting or you can provide them to the `StartTranscription` API call. Languages are specified using their international language code (ISO639)
+You can set the transcription languages via a call setting override. Languages are specified using their international language code (ISO639)
 Please note: we currently don’t support changing language settings during the call.
 
 <Tabs groupId="examples">


### PR DESCRIPTION
### Overview

Removes misleading information on how bi-lingual transcriptions can be enabled.
Context: https://getstream.slack.com/archives/C06KGCCCYMU/p1730113632905069